### PR TITLE
Implement JSON project serialization and undoable keyframes

### DIFF
--- a/FrameDirector/Canvas.h
+++ b/FrameDirector/Canvas.h
@@ -21,6 +21,8 @@
 #include <QFont>
 #include <QRubberBand>
 #include <QTimer>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <memory>
 #include <vector>
 #include <map>
@@ -117,6 +119,15 @@ public:
     void clearCurrentFrameContent();
     void copyFrame(int fromFrame, int toFrame);
     void deleteFrame(int frame);
+
+    // Serialization
+    QJsonObject toJson() const;
+    bool fromJson(const QJsonObject& json);
+
+    // Frame data helpers for undo/redo
+    FrameData exportFrameData(int layerIndex, int frame);
+    void importFrameData(int layerIndex, int frame, const FrameData& data);
+    void removeKeyframe(int layerIndex, int frame);
 
     // Frame type queries and navigation
     bool hasKeyframe(int frame) const;
@@ -243,6 +254,8 @@ private:
     void updateSceneRect();
     QGraphicsItem* cloneGraphicsItem(QGraphicsItem* item);
     void clearFrameItems(int frame);
+    QJsonObject serializeGraphicsItem(QGraphicsItem* item) const;
+    QGraphicsItem* deserializeGraphicsItem(const QJsonObject& json) const;
 
     // Drawing and rendering
     void drawGrid(QPainter* painter, const QRectF& rect);

--- a/FrameDirector/Commands/UndoCommands.cpp
+++ b/FrameDirector/Commands/UndoCommands.cpp
@@ -559,3 +559,78 @@ void DrawCommand::redo()
         m_canvas->storeCurrentFrameState();
     }
 }
+
+// Keyframe command implementations
+
+AddKeyframeCommand::AddKeyframeCommand(Canvas* canvas, int layer, int frame, QUndoCommand* parent)
+    : QUndoCommand("Add Keyframe", parent)
+    , m_canvas(canvas)
+    , m_layer(layer)
+    , m_frame(frame)
+{
+    if (m_canvas) {
+        m_previous = m_canvas->exportFrameData(layer, frame);
+    }
+}
+
+AddKeyframeCommand::~AddKeyframeCommand()
+{
+    for (QGraphicsItem* item : m_previous.items) {
+        if (item && !item->scene()) {
+            delete item;
+        }
+    }
+}
+
+void AddKeyframeCommand::redo()
+{
+    if (m_canvas) {
+        m_canvas->setCurrentLayer(m_layer);
+        m_canvas->createKeyframe(m_frame);
+        m_canvas->storeCurrentFrameState();
+    }
+}
+
+void AddKeyframeCommand::undo()
+{
+    if (m_canvas) {
+        m_canvas->importFrameData(m_layer, m_frame, m_previous);
+        m_canvas->storeCurrentFrameState();
+    }
+}
+
+RemoveKeyframeCommand::RemoveKeyframeCommand(Canvas* canvas, int layer, int frame, QUndoCommand* parent)
+    : QUndoCommand("Remove Keyframe", parent)
+    , m_canvas(canvas)
+    , m_layer(layer)
+    , m_frame(frame)
+{
+    if (m_canvas) {
+        m_removed = m_canvas->exportFrameData(layer, frame);
+    }
+}
+
+RemoveKeyframeCommand::~RemoveKeyframeCommand()
+{
+    for (QGraphicsItem* item : m_removed.items) {
+        if (item && !item->scene()) {
+            delete item;
+        }
+    }
+}
+
+void RemoveKeyframeCommand::redo()
+{
+    if (m_canvas) {
+        m_canvas->removeKeyframe(m_layer, m_frame);
+        m_canvas->storeCurrentFrameState();
+    }
+}
+
+void RemoveKeyframeCommand::undo()
+{
+    if (m_canvas) {
+        m_canvas->importFrameData(m_layer, m_frame, m_removed);
+        m_canvas->storeCurrentFrameState();
+    }
+}

--- a/FrameDirector/Commands/UndoCommands.h
+++ b/FrameDirector/Commands/UndoCommands.h
@@ -15,6 +15,7 @@
 #include <memory>
 
 class Canvas;
+struct FrameData;
 
 // Base command for graphics items
 class GraphicsItemCommand : public QUndoCommand
@@ -180,6 +181,37 @@ public:
 private:
     QGraphicsItem* m_item;
     bool m_itemAdded;
+};
+
+// Keyframe commands
+class AddKeyframeCommand : public QUndoCommand
+{
+public:
+    AddKeyframeCommand(Canvas* canvas, int layer, int frame, QUndoCommand* parent = nullptr);
+    ~AddKeyframeCommand();
+    void undo() override;
+    void redo() override;
+
+private:
+    Canvas* m_canvas;
+    int m_layer;
+    int m_frame;
+    FrameData m_previous;
+};
+
+class RemoveKeyframeCommand : public QUndoCommand
+{
+public:
+    RemoveKeyframeCommand(Canvas* canvas, int layer, int frame, QUndoCommand* parent = nullptr);
+    ~RemoveKeyframeCommand();
+    void undo() override;
+    void redo() override;
+
+private:
+    Canvas* m_canvas;
+    int m_layer;
+    int m_frame;
+    FrameData m_removed;
 };
 
 #endif // UNDOCOMMANDS_H


### PR DESCRIPTION
## Summary
- add JSON serialization/deserialization for canvas layers, frames, and items
- introduce AddKeyframeCommand and RemoveKeyframeCommand for undo/redo of keyframes
- wire MainWindow to save/load projects and push keyframe commands onto the undo stack

## Testing
- `apt-get update` *(fails: repository not signed)*
- `g++ -std=c++17 -I. -c Canvas.cpp` *(fails: QGraphicsView not found)*


------
https://chatgpt.com/codex/tasks/task_e_689246d0ed788321ba0d1cf4a0b2a4c1