### PR TITLE
Fix timeline rendering beyond visible area

### DIFF
--- a/FrameDirector/Timeline.h
+++ b/FrameDirector/Timeline.h
@@ -184,8 +184,6 @@ private:
     int m_frameRate;
     bool m_isPlaying;
     double m_zoomLevel;
-    int m_scrollX;
-    int m_scrollY;
 
     // Layout properties
     int m_frameWidth;


### PR DESCRIPTION
## Summary
- Repaint timeline layers and rulers based on visible region, preventing blank space when scrolling
- Compute frame range from paint rect so all timeline UI elements draw in scrolled areas

## Testing
- `g++ -std=c++17 FrameDirector/main.cpp -o FrameDirector/app` *(fails: fatal error: QApplication: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcafa840c8321921a252c79e86339