### PR TITLE
Add basic audio track import and playback

### DIFF
--- a/FrameDirector/MainWindow.h
+++ b/FrameDirector/MainWindow.h
@@ -38,6 +38,8 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QApplication>
+#include <QMediaPlayer>
+#include <QAudioOutput>
 #include <memory>
 #include <vector>
 #include <map>
@@ -154,6 +156,7 @@ private slots:
     void exportAnimation();
     void exportFrame();
     void exportSVG();
+    void onAudioDurationChanged(qint64 duration); // NEW
 
     // Edit menu actions
     void undo();
@@ -349,6 +352,10 @@ private:
     int m_frameRate;
     bool m_isPlaying;
     QTimer* m_playbackTimer;
+    QMediaPlayer* m_audioPlayer; // NEW
+    QAudioOutput* m_audioOutput; // NEW
+    int m_audioFrameLength;      // NEW
+    QString m_audioFile;         // NEW
     QList<QGraphicsItem*> m_clipboardItems;
     QPointF m_clipboardOffset;
 

--- a/FrameDirector/Timeline.h
+++ b/FrameDirector/Timeline.h
@@ -108,6 +108,9 @@ public:
     double getZoomLevel() const;
     void scrollToFrame(int frame);
 
+    // Audio
+    void setAudioTrack(int frames); // NEW
+
     // ENHANCED: Drawing methods with frame extension visualization
     void drawTimelineBackground(QPainter* painter, const QRect& rect);
     void drawFrameRuler(QPainter* painter, const QRect& rect);
@@ -116,10 +119,12 @@ public:
     void drawFrameExtensions(QPainter* painter, const QRect& rect);  // NEW
     void drawPlayhead(QPainter* painter, const QRect& rect);
     void drawSelection(QPainter* painter, const QRect& rect);
+    void drawAudioTrack(QPainter* painter, const QRect& rect); // NEW
 
     // Helper methods for drawing area
     QRect getFrameRect(int frame) const;
     QRect getLayerRect(int layer) const;
+    QRect getAudioTrackRect() const; // NEW
     int getFrameFromX(int x) const;
     int getLayerFromY(int y) const;
     QRect getDrawingAreaRect() const;
@@ -190,6 +195,11 @@ private:
     int m_layerHeight;
     int m_rulerHeight;
     int m_layerPanelWidth;
+
+    // Audio track properties
+    bool m_hasAudioTrack;
+    int m_audioTrackHeight;
+    int m_audioTrackFrames;
 
 
     // ENHANCED: Colors for frame extension visualization


### PR DESCRIPTION
## Summary
- allow importing audio from File > Import and manage it with QMediaPlayer
- render a dedicated audio track at the bottom of the timeline
- synchronize audio playback with timeline controls

## Testing
- `dotnet build FrameDirector.sln` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1643dddcc8321887dc0173284bee2