### PR TITLE
Fix playback frame limit and show audio waveform

### DIFF
--- a/FrameDirector/MainWindow.h
+++ b/FrameDirector/MainWindow.h
@@ -40,6 +40,10 @@
 #include <QApplication>
 #include <QMediaPlayer>
 #include <QAudioOutput>
+#include <QAudioDecoder>
+#include <QAudioBuffer>
+#include <QEventLoop>
+#include <QPixmap>
 #include <memory>
 #include <vector>
 #include <map>
@@ -157,6 +161,7 @@ private slots:
     void exportFrame();
     void exportSVG();
     void onAudioDurationChanged(qint64 duration); // NEW
+    void onTotalFramesChanged(int frames);
 
     // Edit menu actions
     void undo();
@@ -262,6 +267,7 @@ private:
     void updateStatusBar();
     void updateImportMenu();
     void showFrameTypeIndicator();      // Show current frame type in status bar
+    QPixmap createAudioWaveform(const QString& fileName, int samples, int height = 100);
 
 
     struct FrameClipboard {
@@ -356,6 +362,7 @@ private:
     QAudioOutput* m_audioOutput; // NEW
     int m_audioFrameLength;      // NEW
     QString m_audioFile;         // NEW
+    QPixmap m_audioWaveform;     // NEW
     QList<QGraphicsItem*> m_clipboardItems;
     QPointF m_clipboardOffset;
 

--- a/FrameDirector/Timeline.h
+++ b/FrameDirector/Timeline.h
@@ -21,6 +21,8 @@
 #include <QBrush>
 #include <QPen>
 #include <QFont>
+#include <QPixmap>
+#include <QString>
 #include <vector>
 #include <map>
 
@@ -109,7 +111,7 @@ public:
     void scrollToFrame(int frame);
 
     // Audio
-    void setAudioTrack(int frames); // NEW
+    void setAudioTrack(int frames, const QPixmap& waveform = QPixmap(), const QString& label = QString()); // NEW
 
     // ENHANCED: Drawing methods with frame extension visualization
     void drawTimelineBackground(QPainter* painter, const QRect& rect);
@@ -137,6 +139,7 @@ signals:
     void frameExtended(int layer, int frame);  // NEW
     void keyframeSelected(int layer, int frame);
     void layerSelected(int layer);
+    void totalFramesChanged(int frames);
 
 private slots:
     void onFrameSliderChanged(int value);
@@ -200,6 +203,8 @@ private:
     bool m_hasAudioTrack;
     int m_audioTrackHeight;
     int m_audioTrackFrames;
+    QPixmap m_audioWaveform;
+    QString m_audioLabel;
 
 
     // ENHANCED: Colors for frame extension visualization


### PR DESCRIPTION
## Summary
- Synchronize playback length with timeline via new `totalFramesChanged` signal
- Render imported audio as waveform with filename label on the timeline

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c175a0caf48321944b6ac23a9dd281