### PR TITLE
Add blur effect with tweenable slider

### DIFF
--- a/FrameDirector/Animation/AnimationKeyframe.h
+++ b/FrameDirector/Animation/AnimationKeyframe.h
@@ -19,6 +19,7 @@ public:
         double rotation;
         QPointF scale;
         double opacity;
+        double blurRadius;
         QColor strokeColor;
         QColor fillColor;
         double strokeWidth;

--- a/FrameDirector/Commands/UndoCommands.cpp
+++ b/FrameDirector/Commands/UndoCommands.cpp
@@ -8,6 +8,7 @@
 #include <QGraphicsLineItem>
 #include <QGraphicsTextItem>
 #include <QGraphicsPathItem>
+#include <QGraphicsBlurEffect>
 #include <QPen>
 #include <QBrush>
 #include <QTransform>
@@ -345,6 +346,22 @@ void StyleChangeCommand::applyStyle(QGraphicsItem* item, const QString& property
     else if (property == "opacity") {
         item->setData(0, value.toDouble());
         item->setOpacity(value.toDouble());
+    }
+    else if (property == "blur") {
+        double radius = value.toDouble();
+        if (radius > 0) {
+            QGraphicsBlurEffect* blur = qgraphicsitem_cast<QGraphicsBlurEffect*>(item->graphicsEffect());
+            if (!blur) {
+                blur = new QGraphicsBlurEffect();
+                item->setGraphicsEffect(blur);
+            }
+            blur->setBlurRadius(radius);
+        }
+        else {
+            if (item->graphicsEffect()) {
+                item->setGraphicsEffect(nullptr);
+            }
+        }
     }
 }
 

--- a/FrameDirector/Panels/PropertiesPanel.h
+++ b/FrameDirector/Panels/PropertiesPanel.h
@@ -69,6 +69,8 @@ private:
     QDoubleSpinBox* m_strokeWidthSpinBox;
     QSlider* m_opacitySlider;
     QLabel* m_opacityLabel;
+    QSlider* m_blurSlider;
+    QLabel* m_blurLabel;
     QComboBox* m_strokeStyleCombo;
 
     // Animation properties


### PR DESCRIPTION
## Summary
- Add blur slider in Properties panel to apply Gaussian blur to selected items
- Support blur property in keyframes and interpolation for smooth tweening
- Preserve and undo blur changes across clones and edits

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a547270083219c1243fda0cdecdb