### PR TITLE
Add export dialog with progress and fix GIF/MP4 rendering

### DIFF
--- a/FrameDirector/Animation/AnimationController.cpp
+++ b/FrameDirector/Animation/AnimationController.cpp
@@ -328,7 +328,7 @@ void AnimationController::moveKeyframe(int fromFrame, int toFrame)
     }
 }
 
-void AnimationController::exportAnimation(const QString& filename, const QString& format)
+void AnimationController::exportAnimation(const QString& filename, const QString& format, int quality, bool loop)
 {
     if (filename.isEmpty() || m_layers.empty()) {
         return;
@@ -388,10 +388,10 @@ void AnimationController::exportAnimation(const QString& filename, const QString
 
     // Convert frames to final format
     if (format.toLower() == "gif") {
-        success = exportToGif(frameFiles, filename);
+        success = exportToGif(frameFiles, filename, loop);
     }
     else if (format.toLower() == "mp4") {
-        success = exportToMp4(frameFiles, filename);
+        success = exportToMp4(frameFiles, filename, quality);
     }
     else {
         QMessageBox::warning(m_mainWindow, "Export Error", "Unsupported export format: " + format);
@@ -492,7 +492,7 @@ void AnimationController::updateLayerAtFrame(AnimationLayer* layer, int frame)
     }
 }
 
-bool AnimationController::exportToGif(const QStringList& frameFiles, const QString& filename)
+bool AnimationController::exportToGif(const QStringList& frameFiles, const QString& filename, bool loop)
 {
     // This requires an external tool like ImageMagick
     QMessageBox::information(m_mainWindow, "GIF Export",
@@ -503,6 +503,7 @@ bool AnimationController::exportToGif(const QStringList& frameFiles, const QStri
     QProcess process;
     QStringList arguments;
     arguments << "-delay" << QString::number(100 / m_frameRate);
+    arguments << "-loop" << (loop ? "0" : "1");
     arguments << frameFiles;
     arguments << filename;
     process.setWorkingDirectory(QFileInfo(frameFiles.first()).absolutePath());
@@ -523,7 +524,7 @@ bool AnimationController::exportToGif(const QStringList& frameFiles, const QStri
     return false;
 }
 
-bool AnimationController::exportToMp4(const QStringList& frameFiles, const QString& filename)
+bool AnimationController::exportToMp4(const QStringList& frameFiles, const QString& filename, int quality)
 {
     // This requires FFmpeg
     QMessageBox::information(m_mainWindow, "MP4 Export",
@@ -538,6 +539,8 @@ bool AnimationController::exportToMp4(const QStringList& frameFiles, const QStri
     pattern.replace(QRegularExpression("frame_\\d{4}\\.png"), "frame_%04d.png");
     arguments << "-i" << pattern;
     arguments << "-c:v" << "libx264";
+    int crf = 51 - (quality * 51) / 100;
+    arguments << "-crf" << QString::number(crf);
     arguments << "-pix_fmt" << "yuv420p";
     arguments << "-y"; // Overwrite output file
     arguments << filename;

--- a/FrameDirector/Animation/AnimationController.h
+++ b/FrameDirector/Animation/AnimationController.h
@@ -54,7 +54,7 @@ public:
     void moveKeyframe(int fromFrame, int toFrame);
 
     // Export
-    void exportAnimation(const QString& filename, const QString& format);
+    void exportAnimation(const QString& filename, const QString& format, int quality = 80, bool loop = true);
     void exportFrame(int frame, const QString& filename);
 
 signals:
@@ -75,8 +75,8 @@ private slots:
 private:
     void updateAllLayers();
     void updateLayerAtFrame(AnimationLayer* layer, int frame);
-    bool exportToGif(const QStringList& frameFiles, const QString& filename);
-    bool exportToMp4(const QStringList& frameFiles, const QString& filename);
+    bool exportToGif(const QStringList& frameFiles, const QString& filename, bool loop);
+    bool exportToMp4(const QStringList& frameFiles, const QString& filename, int quality);
     MainWindow* m_mainWindow;
     Timeline* m_timeline;
 

--- a/FrameDirector/FrameDirector.vcxproj
+++ b/FrameDirector/FrameDirector.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="Canvas.cpp" />
     <ClCompile Include="Commands\UndoCommands.cpp" />
     <ClCompile Include="GradientDialog.cpp" />
+    <ClCompile Include="Dialogs\ExportDialog.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MainWindow.cpp" />
     <ClCompile Include="Panels\AlignmentPanel.cpp" />
@@ -149,6 +150,9 @@
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="Animation\AnimationController.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <QtMoc Include="Dialogs\ExportDialog.h" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Animation\AnimationKeyframe.h" />

--- a/FrameDirector/FrameDirector.vcxproj.filters
+++ b/FrameDirector/FrameDirector.vcxproj.filters
@@ -113,6 +113,9 @@
     <ClCompile Include="GradientDialog.cpp">
       <Filter>Dialogs</Filter>
     </ClCompile>
+    <ClCompile Include="Dialogs\ExportDialog.cpp">
+      <Filter>Dialogs</Filter>
+    </ClCompile>
     <ClCompile Include="Tools\GradientFillTool.cpp">
       <Filter>Tools</Filter>
     </ClCompile>
@@ -159,6 +162,9 @@
     </QtMoc>
     <QtMoc Include="Tools\SelectionTool.h">
       <Filter>Tools</Filter>
+    </QtMoc>
+    <QtMoc Include="Dialogs\ExportDialog.h">
+      <Filter>Dialogs</Filter>
     </QtMoc>
     <QtMoc Include="Tools\TextTool.h">
       <Filter>Tools</Filter>


### PR DESCRIPTION
## Summary
- replace progress dialog with dedicated ExportDialog for format selection and progress feedback
- append missing file extensions and pass quality/loop options to export routines
- update GIF/MP4 exporters to include loop flag and CRF quality control

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae7fed908321ac77954b0ddaac08