### PR TITLE
Enable tweening for imported images

### DIFF
--- a/FrameDirector/Animation/AnimationKeyframe.cpp
+++ b/FrameDirector/Animation/AnimationKeyframe.cpp
@@ -4,6 +4,7 @@
 #include <QGraphicsEllipseItem>
 #include <QGraphicsPathItem>
 #include <QGraphicsTextItem>
+#include <QGraphicsPixmapItem>
 #include <QGraphicsBlurEffect>
 #include <QtMath>
 #include <QPen>        // Add this

--- a/FrameDirector/Canvas.cpp
+++ b/FrameDirector/Canvas.cpp
@@ -8,6 +8,7 @@
 #include <QGraphicsScene>
 #include <QGraphicsItem>
 #include <QGraphicsPathItem>
+#include <QGraphicsPixmapItem>
 #include <QGraphicsBlurEffect>
 #include <QMouseEvent>
 #include <QWheelEvent>
@@ -1105,6 +1106,15 @@ QGraphicsItem* Canvas::cloneGraphicsItem(QGraphicsItem* item)
         newPath->setPos(pathItem->pos());
         newPath->setRotation(pathItem->rotation());
         copy = newPath;
+    }
+    else if (auto pixmapItem = qgraphicsitem_cast<QGraphicsPixmapItem*>(item)) {
+        // Handle imported images
+        auto newPixmap = new QGraphicsPixmapItem(pixmapItem->pixmap());
+        newPixmap->setTransform(pixmapItem->transform());
+        newPixmap->setPos(pixmapItem->pos());
+        newPixmap->setRotation(pixmapItem->rotation());
+        newPixmap->setOffset(pixmapItem->offset());
+        copy = newPixmap;
     }
     else if (auto textItem = qgraphicsitem_cast<QGraphicsTextItem*>(item)) {
         auto newText = new QGraphicsTextItem(textItem->toPlainText());


### PR DESCRIPTION
## Summary
- Clone QGraphicsPixmapItem when tweening so imported images appear on interpolated frames
- Include pixmap item headers in canvas and keyframe modules

## Testing
- `dotnet build FrameDirector.sln` *(fails: The imported project "/Microsoft.Cpp.Default.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c08a66c8832192449063afe49570