### PR TITLE
Rotate items around their center

### DIFF
--- a/FrameDirector/Canvas.cpp
+++ b/FrameDirector/Canvas.cpp
@@ -1748,8 +1748,9 @@ void Canvas::rotateSelected(double angle)
     if (!m_scene) return;
     QList<QGraphicsItem*> selectedItems = m_scene->selectedItems();
     for (QGraphicsItem* item : selectedItems) {
-        QPointF center = item->boundingRect().center();
-        item->setTransformOriginPoint(center);
+        QPointF sceneCenter = item->sceneBoundingRect().center();
+        QPointF itemCenter = item->mapFromScene(sceneCenter);
+        item->setTransformOriginPoint(itemCenter);
         item->setRotation(item->rotation() + angle);
     }
     storeCurrentFrameState();

--- a/FrameDirector/MainWindow.cpp
+++ b/FrameDirector/MainWindow.cpp
@@ -2954,16 +2954,15 @@ void MainWindow::rotateSelected(double angle)
         for (QGraphicsItem* item : selectedItems) {
             QTransform originalTransform = item->transform();
 
-            // Set rotation origin to item center
-            QPointF center = item->boundingRect().center();
-            item->setTransformOriginPoint(center);
+            // Determine the center in scene coordinates and map it back to the item
+            QPointF sceneCenter = item->sceneBoundingRect().center();
+            QPointF itemCenter = item->mapFromScene(sceneCenter);
 
-            // Create new transform with rotation
-            QTransform newTransform = originalTransform;
-            newTransform.translate(center.x(), center.y());
-            newTransform.rotate(angle);
-            newTransform.translate(-center.x(), -center.y());
+            // Rotate around the computed center
+            item->setTransformOriginPoint(itemCenter);
+            item->setRotation(item->rotation() + angle);
 
+            QTransform newTransform = item->transform();
             TransformCommand* transformCommand = new TransformCommand(
                 m_canvas, item, originalTransform, newTransform);
             m_undoStack->push(transformCommand);


### PR DESCRIPTION
## Summary
- Rotate selected items around their visual center by mapping the scene's center back to item coordinates before applying rotation
- Apply the same center-based rotation logic in the canvas helper to keep behavior consistent across the application

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*


------
https://chatgpt.com/codex/tasks/task_e_68c1c77731188321afc2f59cd542901a