### PR TITLE
Rotate items around their center

### DIFF
--- a/FrameDirector/Canvas.cpp
+++ b/FrameDirector/Canvas.cpp
@@ -1748,8 +1748,9 @@ void Canvas::rotateSelected(double angle)
     if (!m_scene) return;
     QList<QGraphicsItem*> selectedItems = m_scene->selectedItems();
     for (QGraphicsItem* item : selectedItems) {
-        QPointF center = item->boundingRect().center();
-        item->setTransformOriginPoint(center);
+        QPointF sceneCenter = item->mapToScene(item->boundingRect().center());
+        item->setTransformOriginPoint(item->boundingRect().center());
+        item->setPos(sceneCenter - item->transformOriginPoint());
         item->setRotation(item->rotation() + angle);
     }
     storeCurrentFrameState();

--- a/FrameDirector/Commands/UndoCommands.cpp
+++ b/FrameDirector/Commands/UndoCommands.cpp
@@ -507,6 +507,9 @@ void PropertyChangeCommand::applyProperty(QGraphicsItem* item, const QString& pr
         item->setPos(value.toPointF());
     }
     else if (property == "rotation") {
+        QPointF sceneCenter = item->mapToScene(item->boundingRect().center());
+        item->setTransformOriginPoint(item->boundingRect().center());
+        item->setPos(sceneCenter - item->transformOriginPoint());
         item->setRotation(value.toDouble());
     }
     else if (property == "scale") {

--- a/FrameDirector/MainWindow.cpp
+++ b/FrameDirector/MainWindow.cpp
@@ -2954,16 +2954,15 @@ void MainWindow::rotateSelected(double angle)
         for (QGraphicsItem* item : selectedItems) {
             QTransform originalTransform = item->transform();
 
-            // Set rotation origin to item center
-            QPointF center = item->boundingRect().center();
-            item->setTransformOriginPoint(center);
+            // Compute the item's visual center in scene coordinates
+            QPointF sceneCenter = item->mapToScene(item->boundingRect().center());
 
-            // Create new transform with rotation
-            QTransform newTransform = originalTransform;
-            newTransform.translate(center.x(), center.y());
-            newTransform.rotate(angle);
-            newTransform.translate(-center.x(), -center.y());
+            // Reposition and rotate around the item's center
+            item->setTransformOriginPoint(item->boundingRect().center());
+            item->setPos(sceneCenter - item->transformOriginPoint());
+            item->setRotation(item->rotation() + angle);
 
+            QTransform newTransform = item->transform();
             TransformCommand* transformCommand = new TransformCommand(
                 m_canvas, item, originalTransform, newTransform);
             m_undoStack->push(transformCommand);

--- a/FrameDirector/Panels/PropertiesPanel.cpp
+++ b/FrameDirector/Panels/PropertiesPanel.cpp
@@ -636,7 +636,10 @@ void PropertiesPanel::onTransformChanged()
         // Position
         item->setPos(m_xSpinBox->value(), m_ySpinBox->value());
 
-        // Rotation
+        // Rotation around the item's center
+        QPointF sceneCenter = item->mapToScene(item->boundingRect().center());
+        item->setTransformOriginPoint(item->boundingRect().center());
+        item->setPos(sceneCenter - item->transformOriginPoint());
         item->setRotation(m_rotationSpinBox->value());
 
         // Scale


### PR DESCRIPTION
## Summary
- Keep item centers fixed by translating to maintain visual center before applying rotation
- Apply center-based pivoting consistently from the canvas, main window actions, properties panel, and property-change commands

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c77731188321afc2f59cd542901a