### PR TITLE
Fix export frame handling

### DIFF
--- a/FrameDirector/Animation/AnimationController.cpp
+++ b/FrameDirector/Animation/AnimationController.cpp
@@ -355,14 +355,18 @@ bool AnimationController::exportAnimation(const QString& filename, const QString
 
     emit exportProgress(0, m_totalFrames);
 
+    // Store original frame so it can be restored after export
+    int originalFrame = m_currentFrame;
+
     // Render each frame
     for (int frame = 1; frame <= m_totalFrames; ++frame) {
         emit exportProgress(frame, m_totalFrames);
-        QApplication::processEvents();
 
         // Set animation to this frame
-        int originalFrame = m_currentFrame;
         setCurrentFrame(frame);
+
+        // Allow UI to update after changing frame
+        QApplication::processEvents();
 
         // Render frame
         QImage frameImage(sceneRect.size().toSize(), QImage::Format_ARGB32);
@@ -379,10 +383,10 @@ bool AnimationController::exportAnimation(const QString& filename, const QString
         QString frameFile = QString("%1/frame_%2.png").arg(tempDir).arg(frame, 4, 10, QChar('0'));
         frameImage.save(frameFile, "PNG");
         frameFiles.append(frameFile);
-
-        // Restore original frame
-        setCurrentFrame(originalFrame);
     }
+
+    // Restore original frame once after rendering all frames
+    setCurrentFrame(originalFrame);
 
     bool success = false;
 


### PR DESCRIPTION
## Summary
- preserve original frame during animation export and restore after all frames render
- process UI events after updating frame to ensure correct first frame

## Testing
- `g++ -fPIC -std=c++17 -c FrameDirector/Animation/AnimationController.cpp $(pkg-config --cflags Qt5Widgets Qt5Svg Qt5Core Qt5Gui Qt5PrintSupport Qt5Multimedia) -IFrameDirector -o /tmp/AnimationController.o`


------
https://chatgpt.com/codex/tasks/task_e_68c52290fa308321b2e8911bd0ffdaa6