### PR TITLE
Fix frame copy/paste and enable object resizing

### DIFF
--- a/FrameDirector/MainWindow.cpp
+++ b/FrameDirector/MainWindow.cpp
@@ -22,6 +22,7 @@
 #include "Animation/AnimationController.h"
 #include "Dialogs/ExportDialog.h"
 #include "Import/ORAImporter.h"
+#include "VectorGraphics/VectorGraphicsItem.h"
 
 #include <QApplication>
 #include <QMenuBar>
@@ -2395,19 +2396,12 @@ void MainWindow::copyCurrentFrame()
     if (frameType == FrameType::ExtendedFrame) {
         int sourceFrame = m_canvas->getSourceKeyframe(m_currentFrame);
         if (sourceFrame != -1) {
-            // Get items from source keyframe
-            auto frameData = m_canvas->getFrameData(sourceFrame);
-            if (frameData.has_value()) {
-                currentFrameItems = frameData->items;
-            }
+            currentFrameItems = m_canvas->getFrameItems(sourceFrame);
         }
     }
     else {
         // Get items directly from current frame
-        auto frameData = m_canvas->getFrameData(m_currentFrame);
-        if (frameData.has_value()) {
-            currentFrameItems = frameData->items;
-        }
+        currentFrameItems = m_canvas->getFrameItems(m_currentFrame);
     }
 
     if (currentFrameItems.isEmpty()) {
@@ -2588,6 +2582,9 @@ QGraphicsItem* MainWindow::duplicateGraphicsItem(QGraphicsItem* item)
             }
         }
         copy = newGroup;
+    }
+    else if (auto vgItem = dynamic_cast<VectorGraphicsItem*>(item)) {
+        copy = cloneVectorGraphicsItem(vgItem);
     }
 
     if (copy) {

--- a/FrameDirector/Tools/SelectionTool.cpp
+++ b/FrameDirector/Tools/SelectionTool.cpp
@@ -4,6 +4,7 @@
 #include "../MainWindow.h"
 #include "../Canvas.h"
 #include "../Commands/UndoCommands.h"
+#include "../VectorGraphics/VectorGraphicsItem.h"
 
 SelectionTool::SelectionTool(MainWindow* mainWindow, QObject* parent)
     : Tool(mainWindow, parent)
@@ -59,6 +60,8 @@ void SelectionTool::mousePressEvent(QMouseEvent* event, const QPointF& scenePos)
         // Right-click context menu
         showContextMenu(event->globalPosition().toPoint());
     }
+
+    updateSelectionHandles();
 }
 
 void SelectionTool::mouseMoveEvent(QMouseEvent* event, const QPointF& scenePos)
@@ -186,6 +189,8 @@ void SelectionTool::deleteSelectedItems()
             m_canvas->storeCurrentFrameState();
         }
     }
+
+    updateSelectionHandles();
 }
 
 void SelectionTool::moveSelectedItems(const QPointF& delta, bool largeStep)
@@ -218,6 +223,17 @@ void SelectionTool::moveSelectedItems(const QPointF& delta, bool largeStep)
     }
 }
 
+void SelectionTool::updateSelectionHandles()
+{
+    if (!m_canvas || !m_canvas->scene()) return;
+
+    for (QGraphicsItem* item : m_canvas->scene()->items()) {
+        if (auto vgItem = dynamic_cast<VectorGraphicsItem*>(item)) {
+            vgItem->setShowSelectionHandles(item->isSelected());
+        }
+    }
+}
+
 void SelectionTool::groupSelectedItems()
 {
     if (!m_canvas || !m_canvas->scene()) return;
@@ -241,6 +257,8 @@ void SelectionTool::groupSelectedItems()
             m_canvas->storeCurrentFrameState();
         }
     }
+
+    updateSelectionHandles();
 }
 
 void SelectionTool::ungroupSelectedItems()
@@ -269,6 +287,8 @@ void SelectionTool::ungroupSelectedItems()
             break; // Only ungroup one at a time
         }
     }
+
+    updateSelectionHandles();
 }
 void SelectionTool::showContextMenu(const QPoint& globalPos)
 {

--- a/FrameDirector/Tools/SelectionTool.h
+++ b/FrameDirector/Tools/SelectionTool.h
@@ -31,6 +31,7 @@ private slots:
 private:
     void moveSelectedItems(const QPointF& delta, bool largeStep = false);
     void showContextMenu(const QPoint& globalPos);
+    void updateSelectionHandles();
 
     // Dragging state
     bool m_dragging;

--- a/FrameDirector/VectorGraphics/VectorGraphicsItem.cpp
+++ b/FrameDirector/VectorGraphics/VectorGraphicsItem.cpp
@@ -613,3 +613,36 @@ public:
 private:
     QPainterPath m_path;
 };
+
+VectorGraphicsItem* cloneVectorGraphicsItem(const VectorGraphicsItem* item)
+{
+    if (!item) {
+        return nullptr;
+    }
+
+    QJsonObject json = item->toJson();
+    VectorGraphicsItem* newItem = nullptr;
+
+    switch (item->getItemType()) {
+    case VectorGraphicsItem::VectorRectangle:
+        newItem = new VectorRectangleItem(QRectF());
+        break;
+    case VectorGraphicsItem::VectorEllipse:
+        newItem = new VectorEllipseItem(QRectF());
+        break;
+    case VectorGraphicsItem::VectorLine:
+        newItem = new VectorLineItem(QLineF());
+        break;
+    case VectorGraphicsItem::VectorPath:
+        newItem = new VectorPathItem(QPainterPath());
+        break;
+    default:
+        break;
+    }
+
+    if (newItem) {
+        newItem->fromJson(json);
+    }
+
+    return newItem;
+}

--- a/FrameDirector/VectorGraphics/VectorGraphicsItem.h
+++ b/FrameDirector/VectorGraphics/VectorGraphicsItem.h
@@ -75,4 +75,7 @@ protected:
     QPointF m_lastMousePos;
 };
 
+// Utility helper to duplicate vector graphics items
+VectorGraphicsItem* cloneVectorGraphicsItem(const VectorGraphicsItem* item);
+
 #endif


### PR DESCRIPTION
## Summary
- Copy frames by collecting items via `getFrameItems`
- Support duplicating custom vector items
- Toggle selection handles for resizing when selection changes

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `g++ -c FrameDirector/MainWindow.cpp` *(fails: QGraphicsItem: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5240e7b5883219ff86a8fc8230e31