### PR TITLE
Crop export to canvas bounds

### DIFF
--- a/FrameDirector/Animation/AnimationController.cpp
+++ b/FrameDirector/Animation/AnimationController.cpp
@@ -342,10 +342,10 @@ bool AnimationController::exportAnimation(const QString& filename, const QString
     }
 
     QGraphicsScene* scene = canvas->scene();
-    QRectF sceneRect = scene->itemsBoundingRect();
-    if (sceneRect.isEmpty()) {
-        sceneRect = scene->sceneRect();
-    }
+    // Use the canvas's defined rectangle to ensure export size matches the
+    // intended canvas dimensions (default 1920x1080) rather than expanding to
+    // include items that extend beyond the canvas area.
+    QRectF sceneRect = canvas->getCanvasRect();
 
     // Create temporary directory for frames
     QString tempDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/framedirector_export";
@@ -433,10 +433,9 @@ void AnimationController::exportFrame(int frame, const QString& filename)
     setCurrentFrame(frame);
 
     QGraphicsScene* scene = canvas->scene();
-    QRectF sceneRect = scene->itemsBoundingRect();
-    if (sceneRect.isEmpty()) {
-        sceneRect = scene->sceneRect();
-    }
+    // Restrict export to the canvas bounds to avoid resizing when items extend
+    // beyond the visible canvas area.
+    QRectF sceneRect = canvas->getCanvasRect();
 
     // Determine format from filename
     QFileInfo fileInfo(filename);


### PR DESCRIPTION
## Summary
- Restrict animation and frame exports to the canvas rectangle
- Prevent exported frames from expanding to include off‑canvas items

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `cmake .` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c568a202a883218607128830cf4fb4