### PR TITLE
Reset playhead before exporting animations

### DIFF
--- a/FrameDirector/MainWindow.cpp
+++ b/FrameDirector/MainWindow.cpp
@@ -1682,6 +1682,10 @@ void MainWindow::exportAnimation()
     if (!fileName.endsWith('.' + format, Qt::CaseInsensitive))
         fileName += '.' + format;
 
+    int originalFrame = m_timeline ? m_timeline->getCurrentFrame() : 1;
+    if (m_timeline)
+        m_timeline->setCurrentFrame(1);
+
     AnimationController controller(this);
     int totalFrames = m_timeline ? m_timeline->getTotalFrames() : 0;
     if (m_timeline)
@@ -1694,6 +1698,9 @@ void MainWindow::exportAnimation()
     bool ok = controller.exportAnimation(fileName, format, options.getQuality(), options.getLoop());
     options.close();
     m_statusLabel->setText(ok ? "Animation exported" : "Export failed");
+
+    if (m_timeline)
+        m_timeline->setCurrentFrame(originalFrame);
 }
 
 void MainWindow::exportFrame()


### PR DESCRIPTION
## Summary
- Ensure timeline playhead jumps to frame 1 when exporting an animation
- Restore original frame once export completes to preserve user context

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59e4eb2548321bf7ef68c4586ce36