### PR TITLE
Use dedicated first/last frame icons

### DIFF
--- a/FrameDirector/FrameDirector.vcxproj
+++ b/FrameDirector/FrameDirector.vcxproj
@@ -254,6 +254,12 @@
     <Image Include="resources\icons\arrow-right.png">
       <DeploymentContent>true</DeploymentContent>
     </Image>
+    <Image Include="resources\icons\double-arrow-left.png">
+      <DeploymentContent>true</DeploymentContent>
+    </Image>
+    <Image Include="resources\icons\double-arrow-right.png">
+      <DeploymentContent>true</DeploymentContent>
+    </Image>
     <Image Include="resources\icons\branch-closed.png">
       <DeploymentContent>true</DeploymentContent>
     </Image>

--- a/FrameDirector/FrameDirector.vcxproj.filters
+++ b/FrameDirector/FrameDirector.vcxproj.filters
@@ -431,6 +431,12 @@
     <Image Include="resources\icons\arrow-right.png">
       <Filter>Resource Files</Filter>
     </Image>
+    <Image Include="resources\icons\double-arrow-left.png">
+      <Filter>Resource Files</Filter>
+    </Image>
+    <Image Include="resources\icons\double-arrow-right.png">
+      <Filter>Resource Files</Filter>
+    </Image>
     <Image Include="resources\icons\branch-closed.png">
       <Filter>Resource Files</Filter>
     </Image>

--- a/FrameDirector/MainWindow.cpp
+++ b/FrameDirector/MainWindow.cpp
@@ -613,26 +613,12 @@ void MainWindow::createActions()
     connect(m_prevFrameAction, &QAction::triggered, this, &MainWindow::previousFrame);
 
     m_firstFrameAction = new QAction("&First Frame", this);
-    // Create a double left arrow for first frame
-    QPixmap firstFrame = QIcon(":/icons/arrow-right.png").pixmap(16, 16);
-    QPixmap doubleLeft(32, 16);
-    doubleLeft.fill(Qt::transparent);
-    QPainter painter(&doubleLeft);
-    painter.drawPixmap(0, 0, firstFrame.transformed(transform));
-    painter.drawPixmap(10, 0, firstFrame.transformed(transform));
-    m_firstFrameAction->setIcon(QIcon(doubleLeft));
+    m_firstFrameAction->setIcon(QIcon(":/icons/double-arrow-left.png"));
     m_firstFrameAction->setShortcut(QKeySequence("Home"));
     connect(m_firstFrameAction, &QAction::triggered, this, &MainWindow::firstFrame);
 
     m_lastFrameAction = new QAction("&Last Frame", this);
-    // Create a double right arrow for last frame
-    QPixmap lastFrame = QIcon(":/icons/arrow-right.png").pixmap(16, 16);
-    QPixmap doubleRight(32, 16);
-    doubleRight.fill(Qt::transparent);
-    QPainter painter2(&doubleRight);
-    painter2.drawPixmap(0, 0, lastFrame);
-    painter2.drawPixmap(10, 0, lastFrame);
-    m_lastFrameAction->setIcon(QIcon(doubleRight));
+    m_lastFrameAction->setIcon(QIcon(":/icons/double-arrow-right.png"));
     m_lastFrameAction->setShortcut(QKeySequence("End"));
     connect(m_lastFrameAction, &QAction::triggered, this, &MainWindow::lastFrame);
 

--- a/FrameDirector/Timeline.cpp
+++ b/FrameDirector/Timeline.cpp
@@ -625,7 +625,7 @@ void Timeline::setupControls()
 
     // Playback controls with icons
     m_firstFrameButton = new QPushButton();
-    m_firstFrameButton->setIcon(QIcon(":/icons/arrow-right.png")); // Will be rotated to create double-left
+    m_firstFrameButton->setIcon(QIcon(":/icons/double-arrow-left.png"));
     m_firstFrameButton->setToolTip("First Frame");
 
     m_prevFrameButton = new QPushButton();
@@ -650,7 +650,7 @@ void Timeline::setupControls()
     m_nextFrameButton->setToolTip("Next Frame");
 
     m_lastFrameButton = new QPushButton();
-    m_lastFrameButton->setIcon(QIcon(":/icons/arrow-right.png"));
+    m_lastFrameButton->setIcon(QIcon(":/icons/double-arrow-right.png"));
     m_lastFrameButton->setToolTip("Last Frame");
 
     // Style buttons with Flash-like appearance

--- a/FrameDirector/resources/icons.qrc
+++ b/FrameDirector/resources/icons.qrc
@@ -65,7 +65,7 @@
 
         <!-- Animation Control Icons (24x24) -->
         <file>icons/double-arrow-left.png</file>
-        <file>icons/double-arrow-left.png</file>
+        <file>icons/double-arrow-right.png</file>
         <file>icons/Play.png</file>
         <file>icons/pause.png</file>
         <file>icons/stop.png</file>


### PR DESCRIPTION
## Summary
- Use new double-arrow icons for first/last frame actions
- Register double-arrow icons in Qt resources and project files

## Testing
- `dotnet build FrameDirector.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a7d1c5b883219dd4331bf8e9e234