### PR TITLE
Fix grouping/ungrouping selection to move items correctly

### DIFF
--- a/FrameDirector/Commands/UndoCommands.cpp
+++ b/FrameDirector/Commands/UndoCommands.cpp
@@ -401,8 +401,16 @@ GroupCommand::~GroupCommand()
 void GroupCommand::undo()
 {
     if (m_canvas && m_canvas->scene() && m_group && isItemValid(m_group)) {
+        QList<QGraphicsItem*> children = m_group->childItems();
         m_canvas->scene()->destroyItemGroup(m_group);
+        m_group = nullptr;
         m_grouped = false;
+        m_canvas->scene()->clearSelection();
+        for (QGraphicsItem* child : children) {
+            if (isItemValid(child)) {
+                child->setSelected(true);
+            }
+        }
         m_canvas->storeCurrentFrameState();
     }
 }
@@ -422,6 +430,9 @@ void GroupCommand::redo()
             m_group = m_canvas->scene()->createItemGroup(validItems);
             m_group->setFlag(QGraphicsItem::ItemIsSelectable, true);
             m_group->setFlag(QGraphicsItem::ItemIsMovable, true);
+            m_canvas->addItemToCurrentLayer(m_group);
+            m_canvas->scene()->clearSelection();
+            m_group->setSelected(true);
             m_grouped = true;
             m_canvas->storeCurrentFrameState();
         }
@@ -458,6 +469,9 @@ void UngroupCommand::undo()
             m_group = m_canvas->scene()->createItemGroup(validItems);
             m_group->setFlag(QGraphicsItem::ItemIsSelectable, true);
             m_group->setFlag(QGraphicsItem::ItemIsMovable, true);
+            m_canvas->addItemToCurrentLayer(m_group);
+            m_canvas->scene()->clearSelection();
+            m_group->setSelected(true);
             m_ungrouped = false;
             m_canvas->storeCurrentFrameState();
         }
@@ -467,7 +481,15 @@ void UngroupCommand::undo()
 void UngroupCommand::redo()
 {
     if (m_canvas && m_canvas->scene() && m_group && isItemValid(m_group)) {
+        QList<QGraphicsItem*> children = m_group->childItems();
         m_canvas->scene()->destroyItemGroup(m_group);
+        m_group = nullptr;
+        m_canvas->scene()->clearSelection();
+        for (QGraphicsItem* child : children) {
+            if (isItemValid(child)) {
+                child->setSelected(true);
+            }
+        }
         m_ungrouped = true;
         m_canvas->storeCurrentFrameState();
     }


### PR DESCRIPTION
## Summary
- Use canvas helpers for direct group/ungroup operations in SelectionTool
- Ensure Group/Ungroup undo commands clear selections and manage grouped items properly

## Testing
- `cmake .` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c68ec1329c83219193cc36be14a8ea