### PR TITLE
Preserve stacking order of items when saving frames

### DIFF
--- a/FrameDirector/Canvas.cpp
+++ b/FrameDirector/Canvas.cpp
@@ -590,8 +590,10 @@ void Canvas::saveFrameState(int frame)
     qDebug() << "Saving frame state for frame:" << frame << "layer:" << m_currentLayerIndex;
 
     // Collect current layer items from scene
+    // Use ascending order so items are stored from back to front,
+    // ensuring their stacking order is preserved when reloaded
     QList<QGraphicsItem*> currentLayerItems;
-    for (QGraphicsItem* item : m_scene->items()) {
+    for (QGraphicsItem* item : m_scene->items(Qt::AscendingOrder)) {
         if (item != m_backgroundRect &&
             getItemLayerIndex(item) == m_currentLayerIndex &&
             !m_onionSkinItems.contains(item)) {


### PR DESCRIPTION
## Summary
- Ensure items are stored from back to front when capturing a frame so their z-order remains intact across frame changes

## Testing
- `cmake -S . -B build` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68c6abb6c10c8321bcbcb3e5b8509491