### PR TITLE
Clear timeline on new project

### DIFF
--- a/FrameDirector/MainWindow.cpp
+++ b/FrameDirector/MainWindow.cpp
@@ -1199,6 +1199,14 @@ void MainWindow::newFile()
         m_totalFrames = 150;
         m_currentFile.clear();
         m_isModified = false;
+
+        if (m_timeline) {
+            m_timeline->clearKeyframes();
+            m_timeline->setTotalFrames(m_totalFrames);
+            m_timeline->setCurrentFrame(m_currentFrame);
+            m_timeline->updateLayersFromCanvas();
+        }
+
         addLayer();
         updateUI();
         setWindowTitle("FrameDirector - Untitled");

--- a/FrameDirector/Timeline.cpp
+++ b/FrameDirector/Timeline.cpp
@@ -381,6 +381,15 @@ void Timeline::toggleKeyframe(int layer, int frame)
     }
 }
 
+void Timeline::clearKeyframes()
+{
+    m_keyframes.clear();
+    m_selectedKeyframes.clear();
+    if (m_drawingArea) {
+        m_drawingArea->update();
+    }
+}
+
 void Timeline::setupUI()
 {
     m_mainLayout = new QVBoxLayout(this);

--- a/FrameDirector/Timeline.h
+++ b/FrameDirector/Timeline.h
@@ -95,6 +95,7 @@ public:
 
     void selectKeyframe(int layer, int frame);
     void clearKeyframeSelection();
+    void clearKeyframes();
     void toggleKeyframe(int layer, int frame);
 
     // Layers


### PR DESCRIPTION
## Summary
- Reset timeline when starting a new project by clearing all keyframes and resyncing layers
- Add Timeline::clearKeyframes helper and use it when creating a new file

## Testing
- `msbuild FrameDirector.sln`
- `make`
- `qmake`
- `cmake .`

------
https://chatgpt.com/codex/tasks/task_e_68c7fd52fe8083218c9d725c3246b279