### PR TITLE
Ensure new projects reset to a blank timeline

### DIFF
--- a/FrameDirector/MainWindow.cpp
+++ b/FrameDirector/MainWindow.cpp
@@ -1191,26 +1191,44 @@ void MainWindow::connectLayerManager()
 // File operations
 void MainWindow::newFile()
 {
-    if (maybeSave()) {
+    if (!maybeSave())
+        return;
+
+    if (m_canvas) {
         m_canvas->clear();
-        m_layers.clear();
-        m_keyframes.clear();
-        m_currentFrame = 1;
-        m_totalFrames = 150;
-        m_currentFile.clear();
-        m_isModified = false;
-
-        if (m_timeline) {
-            m_timeline->clearKeyframes();
-            m_timeline->setTotalFrames(m_totalFrames);
-            m_timeline->setCurrentFrame(m_currentFrame);
-            m_timeline->updateLayersFromCanvas();
-        }
-
-        addLayer();
-        updateUI();
-        setWindowTitle("FrameDirector - Untitled");
     }
+
+    m_layers.clear();
+    m_keyframes.clear();
+    m_currentFrame = 1;
+    m_totalFrames = 150;
+    m_currentFile.clear();
+    m_isModified = false;
+
+    // Reset audio state for a completely blank project
+    m_audioFile.clear();
+    m_audioFrameLength = 0;
+    m_audioWaveform = QPixmap();
+    if (m_audioPlayer) {
+        m_audioPlayer->stop();
+        m_audioPlayer->setSource(QUrl());
+    }
+
+    if (m_timeline) {
+        m_timeline->resetForNewProject();
+        m_timeline->setTotalFrames(m_totalFrames);
+        m_timeline->updateLayersFromCanvas();
+
+        int defaultLayer = 0;
+        if (m_canvas && m_canvas->getLayerCount() > 1) {
+            defaultLayer = 1; // Prefer the primary drawing layer when it exists
+        }
+        m_timeline->setSelectedLayer(defaultLayer);
+    }
+
+    addLayer();
+    updateUI();
+    setWindowTitle("FrameDirector - Untitled");
 }
 
 void MainWindow::open()

--- a/FrameDirector/Timeline.cpp
+++ b/FrameDirector/Timeline.cpp
@@ -390,6 +390,39 @@ void Timeline::clearKeyframes()
     }
 }
 
+void Timeline::resetForNewProject()
+{
+    clearKeyframes();
+
+    // Remove any timeline-specific layer state so we rebuild from the canvas
+    m_layers.clear();
+    if (m_layerList) {
+        QSignalBlocker blocker(m_layerList);
+        m_layerList->clear();
+    }
+
+    // Clear audio information and force the layout to shrink
+    setAudioTrack(0, QPixmap(), QString());
+
+    // Reset frame controls back to the first frame without emitting signals
+    m_currentFrame = 1;
+    if (m_frameSpinBox) {
+        QSignalBlocker blocker(m_frameSpinBox);
+        m_frameSpinBox->setValue(1);
+    }
+    if (m_frameSlider) {
+        QSignalBlocker blocker(m_frameSlider);
+        m_frameSlider->setValue(1);
+    }
+
+    m_selectedLayer = -1;
+
+    updateLayout();
+    if (m_drawingArea) {
+        m_drawingArea->update();
+    }
+}
+
 void Timeline::setupUI()
 {
     m_mainLayout = new QVBoxLayout(this);

--- a/FrameDirector/Timeline.h
+++ b/FrameDirector/Timeline.h
@@ -96,6 +96,7 @@ public:
     void selectKeyframe(int layer, int frame);
     void clearKeyframeSelection();
     void clearKeyframes();
+    void resetForNewProject();
     void toggleKeyframe(int layer, int frame);
 
     // Layers


### PR DESCRIPTION
## Summary
- rebuild the canvas when starting a new project so only the background and the default drawing layer remain
- add a timeline reset helper and invoke it from the new project flow to clear keyframes, layers, and audio
- reset audio bookkeeping and keep prompting users to save before discarding their current work

## Testing
- not run (Qt build environment unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68c84b4275608321a05b95a07cc1bfb7