### PR TITLE
Improve drawing stabilizer smoothing

### DIFF
--- a/FrameDirector/Tools/DrawingTool.h
+++ b/FrameDirector/Tools/DrawingTool.h
@@ -69,6 +69,8 @@ private:
     // Stabilizer system
     QTimer* m_stabilizerTimer;
     QList<QPointF> m_stabilizerPoints;
+    QPointF m_smoothedPoint;
+    bool m_hasSmoothedPoint;
 };
 
 #endif // DRAWINGTOOL_H


### PR DESCRIPTION
## Summary
- maintain a smoothed cursor position for each stroke so the stabilizer can filter raw samples instead of delaying them
- replace the previous single-point averaging with a trailing window blend that adjusts to backlog and catches up smoothly when the cursor speeds up

## Testing
- not run (Qt/Windows build environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca71f841ac8321ac6e21fb2ccfa90e