### PR TITLE
Improve bucket fill region detection

### DIFF
--- a/FrameDirector/BucketFillTool.h
+++ b/FrameDirector/BucketFillTool.h
@@ -68,6 +68,8 @@ private:
     QList<PathSegment> collectNearbyPaths(const QPointF& center, qreal searchRadius = 50.0);
     QPainterPath mergeIntersectingPaths(const QList<PathSegment>& segments);
     QPainterPath createClosedPath(const QList<PathSegment>& segments, const QPointF& seedPoint);
+    ClosedRegion buildClosedRegionFromSegments(const QList<PathSegment>& segments,
+        const QPointF& seedPoint, qreal searchRadius);
     bool isPathClosed(const QPainterPath& path, qreal tolerance = 2.0);
     QPainterPath closeOpenPath(const QPainterPath& path, qreal tolerance = 5.0);
 


### PR DESCRIPTION
## Summary
- enhance the bucket fill tool to try multiple search radii and run an advanced reconstruction pass when looking for closed regions
- build closed regions by thickening nearby strokes, respecting filled shapes as obstacles, and filtering out open areas that touch search bounds
- skip the preview item when gathering segments so only real geometry contributes to fills

## Testing
- not run (Qt/GUI project)


------
https://chatgpt.com/codex/tasks/task_e_68ca9f484b148321b10de29334ffaafb