### PR TITLE
Improve drawing stabilizer smoothing

### DIFF
--- a/FrameDirector/Tools/DrawingTool.h
+++ b/FrameDirector/Tools/DrawingTool.h
@@ -42,6 +42,7 @@ public:
     int getStabilizerAmount() const;
     bool isSmoothingEnabled() const;
     bool isPressureSensitive() const;
+    int getStabilizerDelayMs() const;
 
     // Settings dialog
     void showSettingsDialog();
@@ -53,6 +54,7 @@ private:
     void addPointToPath(const QPointF& point);
     void applySmoothingToPath();
     void updateStabilizerDelay();
+    void processStabilizerPoints(bool forceFlush);
     // Drawing state
     bool m_drawing;
     QGraphicsPathItem* m_currentPath;


### PR DESCRIPTION
## Summary
- revamp the drawing stabilizer to process queued samples immediately and use a weighted window for smoother output
- add adaptive follow behaviour so the stabilized stroke catches up when lagging and flush remaining points on release
- expose the actual stabilizer delay in the settings UI while keeping the timer running at a precise interval

## Testing
- not run (Qt build environment is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68cbf0a533c083218404c137fc985563