### PR TITLE
Fix polygon area computation for bucket fill regions

### DIFF
--- a/FrameDirector/BucketFillTool.h
+++ b/FrameDirector/BucketFillTool.h
@@ -70,6 +70,8 @@ private:
     QPainterPath createClosedPath(const QList<PathSegment>& segments, const QPointF& seedPoint);
     ClosedRegion buildClosedRegionFromSegments(const QList<PathSegment>& segments,
         const QPointF& seedPoint, qreal searchRadius);
+    ClosedRegion buildClosedRegionUsingRaster(const QList<PathSegment>& segments,
+        const QPointF& seedPoint, qreal searchRadius);
     bool isPathClosed(const QPainterPath& path, qreal tolerance = 2.0);
     QPainterPath closeOpenPath(const QPainterPath& path, qreal tolerance = 5.0);
 


### PR DESCRIPTION
## Summary
- compute fill polygon area using a QPainterPath so the code works across Qt builds without QPolygonF::area
- maintain the small-region filter while ensuring complex fill detection still selects the correct candidate

## Testing
- not run (project has no automated tests in container)

------
https://chatgpt.com/codex/tasks/task_e_68cbf87f76888321ac6d4e2394096ab2