### PR TITLE
Improve bucket fill performance and reliability

### DIFF
--- a/FrameDirector/BucketFillTool.h
+++ b/FrameDirector/BucketFillTool.h
@@ -90,6 +90,8 @@ private:
         const QColor& targetColor, const QColor& fillColor);
     int floodFillImageLimited(QImage& image, const QPoint& startPoint,
         const QColor& targetColor, const QColor& fillColor, int maxPixels);
+    ClosedRegion floodFillRegionFromArea(const QRectF& area, const QPointF& seedPoint, bool& touchesEdge);
+    bool colorsSimilar(QRgb first, QRgb second) const;
 
     // Advanced contour tracing (Moore neighborhood algorithm)
     QPainterPath traceFilledRegion(const QImage& image, const QColor& fillColor);


### PR DESCRIPTION
## Summary
- replace the multi-pass path search in the bucket fill tool with an adaptive raster flood fill that determines enclosed regions more quickly
- wire mouse handling to the new region detection while keeping the fill mode 1 fallback for whole-canvas fills
- ensure created fills render beneath artwork by setting their Z value immediately instead of relying on a delayed timer

## Testing
- not run (Qt project requires tooling that is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc053511cc8321be8c347da6f032c2