### PR TITLE
Improve bucket fill smoothing and z-order

### DIFF
--- a/FrameDirector/Common/GraphicsItemRoles.h
+++ b/FrameDirector/Common/GraphicsItemRoles.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QtCore/Qt>
+
+namespace GraphicsItemRoles {
+
+// Role used to hint that an item should be positioned behind stroke content
+// when it is inserted into a layer. This is primarily used by the bucket fill
+// tool so that the generated fill does not cover the original drawing stroke.
+inline constexpr int BucketFillBehindStrokeRole = Qt::UserRole + 501;
+
+} // namespace GraphicsItemRoles
+


### PR DESCRIPTION
## Summary
- apply polygon smoothing steps to the bucket fill raster trace so filled regions lose pixelated corners
- add a shared graphics item role for bucket fills and tag the created path items with it
- update canvas layer insertion logic to honor the hint and keep fills behind existing stroke content

## Testing
- not run (Qt project)


------
https://chatgpt.com/codex/tasks/task_e_68cc19c3b7d08321a2b7b2a117ff57e5