### PR TITLE
Fix bucket fill binary mask handling

### DIFF
--- a/FrameDirector/BucketFillTool.h
+++ b/FrameDirector/BucketFillTool.h
@@ -97,9 +97,9 @@ private:
     bool colorsSimilar(QRgb first, QRgb second) const;
 
     // Advanced contour tracing (Moore neighborhood algorithm)
-    QPainterPath traceFilledRegion(const QImage& image, const QColor& fillColor);
-    QVector<QPointF> traceContour(const QImage& image, const QPoint& startPoint, const QColor& fillColor);
-    QPoint findStartPoint(const QImage& image, const QColor& fillColor);
+    QPainterPath traceFilledRegion(const QImage& image, const QColor& fillColor, bool useAlphaMask = false);
+    QVector<QPointF> traceContour(const QImage& image, const QPoint& startPoint, const QColor& fillColor, bool useAlphaMask);
+    QPoint findStartPoint(const QImage& image, const QColor& fillColor, bool useAlphaMask);
     QList<QPoint> getNeighbors8(const QPoint& point);
     QPoint getNextNeighbor(const QPoint& current, int direction);
     int getDirection(const QPoint& from, const QPoint& to);


### PR DESCRIPTION
## Summary
- build a dedicated alpha mask when rasterising nearby segments and trace the region using an alpha-aware contour walker
- extend the contour tracing helpers to understand binary alpha masks and reuse them for both raster and color-based images
- restore color similarity checks in the raster fallback flood fill while still supporting alpha-only masks

## Testing
- not run (Qt/Visual Studio environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d01d4e54f08321b976f63703527bc4