### PR TITLE
Fix bucket fill mask format regression

### DIFF
--- a/FrameDirector/BucketFillTool.cpp
+++ b/FrameDirector/BucketFillTool.cpp
@@ -999,17 +999,6 @@ BucketFillTool::buildClosedRegionUsingRaster(const QList<PathSegment>& segments,
     }
     pm.end();
 
-    // Work on a binary alpha mask to avoid precision drift from color channels
-    if (mask.format() != QImage::Format_Alpha8 && mask.format() != QImage::Format_Grayscale8) {
-        QImage alphaMask = mask.convertToFormat(QImage::Format_Alpha8);
-        if (alphaMask.isNull()) {
-            alphaMask = mask.convertToFormat(QImage::Format_Grayscale8);
-        }
-        if (!alphaMask.isNull()) {
-            mask = std::move(alphaMask);
-        }
-    }
-
     // ---- 4) Flood fill by ALPHA CLASS only (transparent vs opaque) ----
     const QPointF rel = seedPoint - snappedBounds.topLeft();
     QPoint ip(qRound(rel.x() * S), qRound(rel.y() * S));
@@ -1025,14 +1014,11 @@ BucketFillTool::buildClosedRegionUsingRaster(const QList<PathSegment>& segments,
     const bool seedIsTransparent = (alphaValueAt(mask, ip.x(), ip.y()) < 128);
 
     // Dedicated binary mask that only stores the filled region.
-    QImage fillMask(imgSize, QImage::Format_Alpha8);
-    if (fillMask.isNull()) {
-        fillMask = QImage(imgSize, QImage::Format_Grayscale8);
-    }
+    QImage fillMask(imgSize, QImage::Format_ARGB32);
     if (fillMask.isNull()) {
         return region;
     }
-    fillMask.fill(0);
+    fillMask.fill(Qt::transparent);
 
     QVector<uchar> visited(totalPixels, 0);
     QQueue<QPoint> q; q.enqueue(ip);


### PR DESCRIPTION
## Summary
- keep the bucket-fill obstacle and fill masks in Format_ARGB32 to avoid unsupported 8-bit image paths
- initialize the fill mask as transparent ARGB32 while continuing to treat alpha >= 128 as filled

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d02bd24bcc832195ec6719e6a55dae