### PR TITLE
Integrate Clipper2 implementation for bucket fill

### DIFF
--- a/FrameDirector/BucketFillTool.cpp
+++ b/FrameDirector/BucketFillTool.cpp
@@ -1322,28 +1322,3 @@ int BucketFillTool::getDirection(const QPoint& from, const QPoint& to)
     return 0;
 }
 
-// Add minimal definitions to satisfy linker for missing Clipper2 symbols when
-// the full Clipper2 implementation isn't linked into the project. These
-// implementations are safe-fail placeholders that preserve application
-// stability (operations will fall back if Clipper behaviour isn't available).
-namespace Clipper2Lib {
-
-    // Provide an out-of-line trivial destructor in case it's not linked from
-    // the third-party implementation library. This prevents linker errors.
-    ClipperBase::~ClipperBase() {}
-
-    // No-op safe versions of internal methods. These will cause Execute
-    // operations to report no result (return false or clear outputs) and let
-    // the calling code fall back to raster or legacy paths.
-    void ClipperBase::AddPaths(const Paths64& /*paths*/, PathType /*polytype*/, bool /*is_open*/) { }
-    void ClipperBase::CleanUp() { }
-    bool ClipperBase::ExecuteInternal(ClipType /*ct*/, FillRule /*ft*/, bool /*use_polytrees*/) { return false; }
-
-    // Minimal placeholders for Clipper64/ClipperOffset internals used by BucketFillTool.
-    void Clipper64::BuildTree64(PolyPath64& /*polytree*/, Paths64& /*open_paths*/) { }
-
-    void ClipperOffset::AddPaths(const Paths64& /*paths*/, JoinType /*jt*/, EndType /*et*/) { }
-    void ClipperOffset::Execute(double /*delta*/, Paths64& sols_64) { sols_64.clear(); }
-    void ClipperOffset::Execute(double /*delta*/, PolyTree64& /*polytree*/) { }
-
-} // namespace Clipper2Lib

--- a/FrameDirector/FrameDirector.vcxproj
+++ b/FrameDirector/FrameDirector.vcxproj
@@ -77,6 +77,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)third_party;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -91,6 +92,7 @@
       <ConformanceMode>true</ConformanceMode>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>$(ProjectDir)third_party;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -168,6 +170,9 @@
     <ClCompile Include="third_party\src\stroke.c" />
     <ClCompile Include="third_party\src\threshold.c" />
     <ClCompile Include="third_party\src\thumbnail.c" />
+    <ClCompile Include="third_party\clipper2\src\clipper.engine.cpp" />
+    <ClCompile Include="third_party\clipper2\src\clipper.offset.cpp" />
+    <ClCompile Include="third_party\clipper2\src\clipper.rectclip.cpp" />
     <ClCompile Include="third_party\src\type_tool.c" />
     <ClCompile Include="third_party\test\test.c" />
     <ClCompile Include="Timeline.cpp" />

--- a/FrameDirector/FrameDirector.vcxproj.filters
+++ b/FrameDirector/FrameDirector.vcxproj.filters
@@ -278,6 +278,15 @@
     <ClCompile Include="third_party\src\thumbnail.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="third_party\clipper2\src\clipper.engine.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\clipper2\src\clipper.offset.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\clipper2\src\clipper.rectclip.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="third_party\src\type_tool.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/FrameDirector/third_party/clipper2/src/clipper.engine.cpp
+++ b/FrameDirector/third_party/clipper2/src/clipper.engine.cpp
@@ -1,0 +1,3161 @@
+/*******************************************************************************
+* Author    :  Angus Johnson                                                   *
+* Date      :  15 June 2025                                                    *
+* Website   :  https://www.angusj.com                                          *
+* Copyright :  Angus Johnson 2010-2025                                         *
+* Purpose   :  This is the main polygon clipping module                        *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
+*******************************************************************************/
+
+#include "clipper2/clipper.engine.h"
+#include "clipper2/clipper.h"
+#include <stdexcept>
+
+// https://github.com/AngusJohnson/Clipper2/discussions/334
+// #discussioncomment-4248602
+#if defined(_MSC_VER) && ( defined(_M_AMD64) || defined(_M_X64) )
+#include <xmmintrin.h>
+#include <emmintrin.h>
+#define fmin(a,b) _mm_cvtsd_f64(_mm_min_sd(_mm_set_sd(a),_mm_set_sd(b)))
+#define fmax(a,b) _mm_cvtsd_f64(_mm_max_sd(_mm_set_sd(a),_mm_set_sd(b)))
+#define nearbyint(a) _mm_cvtsd_si64(_mm_set_sd(a)) /* Note: expression type is (int64_t) */
+#endif
+
+namespace Clipper2Lib {
+
+  static const Rect64 invalid_rect = Rect64(false);
+
+  // Every closed path (ie polygon) is made up of a series of vertices forming edge 
+  // 'bounds' that alternate between ascending bounds (containing edges going up 
+  // relative to the Y-axis) and descending bounds. 'Local Minima' refers to
+  // vertices where ascending and descending bounds join at the bottom, and
+  // 'Local Maxima' are where ascending and descending bounds join at the top.
+
+  struct Scanline {
+    int64_t y = 0;
+    Scanline* next = nullptr;
+
+    explicit Scanline(int64_t y_) : y(y_) {}
+  };
+
+  struct HorzSegSorter {
+    inline bool operator()(const HorzSegment& hs1, const HorzSegment& hs2)
+    {
+      if (!hs1.right_op || !hs2.right_op) return (hs1.right_op);
+      return  hs2.left_op->pt.x > hs1.left_op->pt.x;
+    }
+  };
+
+  struct LocMinSorter {
+    inline bool operator()(const LocalMinima_ptr& locMin1,
+      const LocalMinima_ptr& locMin2)
+    {
+      if (locMin2->vertex->pt.y != locMin1->vertex->pt.y)
+        return locMin2->vertex->pt.y < locMin1->vertex->pt.y;
+      else
+        return locMin2->vertex->pt.x > locMin1->vertex->pt.x;
+    }
+  };
+
+
+  inline bool IsOdd(int val)
+  {
+    return (val & 1) ? true : false;
+  }
+
+
+  inline bool IsHotEdge(const Active& e)
+  {
+    return (e.outrec);
+  }
+
+
+  inline bool IsOpen(const Active& e)
+  {
+    return (e.local_min->is_open);
+  }
+
+
+  inline bool IsOpenEnd(const Vertex& v)
+  {
+    return (v.flags & (VertexFlags::OpenStart | VertexFlags::OpenEnd)) !=
+      VertexFlags::Empty;
+  }
+
+
+  inline bool IsOpenEnd(const Active& ae)
+  {
+    return IsOpenEnd(*ae.vertex_top);
+  }
+
+
+  inline Active* GetPrevHotEdge(const Active& e)
+  {
+    Active* prev = e.prev_in_ael;
+    while (prev && (IsOpen(*prev) || !IsHotEdge(*prev)))
+      prev = prev->prev_in_ael;
+    return prev;
+  }
+
+  inline bool IsFront(const Active& e)
+  {
+    return (&e == e.outrec->front_edge);
+  }
+
+  inline bool IsInvalidPath(OutPt* op)
+  {
+    return (!op || op->next == op);
+  }
+
+  /*******************************************************************************
+    *  Dx:                             0(90deg)                                    *
+    *                                  |                                           *
+    *               +inf (180deg) <--- o ---> -inf (0deg)                          *
+    *******************************************************************************/
+
+  inline double GetDx(const Point64& pt1, const Point64& pt2)
+  {
+    double dy = double(pt2.y - pt1.y);
+    if (dy != 0)
+      return double(pt2.x - pt1.x) / dy;
+    else if (pt2.x > pt1.x)
+      return -std::numeric_limits<double>::max();
+    else
+      return std::numeric_limits<double>::max();
+  }
+
+  inline int64_t TopX(const Active& ae, const int64_t currentY)
+  {
+    if ((currentY == ae.top.y) || (ae.top.x == ae.bot.x)) return ae.top.x;
+    else if (currentY == ae.bot.y) return ae.bot.x;
+    else return ae.bot.x + static_cast<int64_t>(nearbyint(ae.dx * (currentY - ae.bot.y)));
+    // nb: std::nearbyint (or std::round) substantially *improves* performance here
+    // as it greatly improves the likelihood of edge adjacency in ProcessIntersectList().
+  }
+
+
+  inline bool IsHorizontal(const Active& e)
+  {
+    return (e.top.y == e.bot.y);
+  }
+
+
+  inline bool IsHeadingRightHorz(const Active& e)
+  {
+    return e.dx == -std::numeric_limits<double>::max();
+  }
+
+
+  inline bool IsHeadingLeftHorz(const Active& e)
+  {
+    return e.dx == std::numeric_limits<double>::max();
+  }
+
+
+  inline void SwapActives(Active*& e1, Active*& e2)
+  {
+    Active* e = e1;
+    e1 = e2;
+    e2 = e;
+  }
+
+  inline PathType GetPolyType(const Active& e)
+  {
+    return e.local_min->polytype;
+  }
+
+  inline bool IsSamePolyType(const Active& e1, const Active& e2)
+  {
+    return e1.local_min->polytype == e2.local_min->polytype;
+  }
+
+  inline void SetDx(Active& e)
+  {
+    e.dx = GetDx(e.bot, e.top);
+  }
+
+  inline Vertex* NextVertex(const Active& e)
+  {
+    if (e.wind_dx > 0)
+      return e.vertex_top->next;
+    else
+      return e.vertex_top->prev;
+  }
+
+  //PrevPrevVertex: useful to get the (inverted Y-axis) top of the
+  //alternate edge (ie left or right bound) during edge insertion.
+  inline Vertex* PrevPrevVertex(const Active& ae)
+  {
+    if (ae.wind_dx > 0)
+      return ae.vertex_top->prev->prev;
+    else
+      return ae.vertex_top->next->next;
+  }
+
+
+  inline Active* ExtractFromSEL(Active* ae)
+  {
+    Active* res = ae->next_in_sel;
+    if (res)
+      res->prev_in_sel = ae->prev_in_sel;
+    ae->prev_in_sel->next_in_sel = res;
+    return res;
+  }
+
+
+  inline void Insert1Before2InSEL(Active* ae1, Active* ae2)
+  {
+    ae1->prev_in_sel = ae2->prev_in_sel;
+    if (ae1->prev_in_sel)
+      ae1->prev_in_sel->next_in_sel = ae1;
+    ae1->next_in_sel = ae2;
+    ae2->prev_in_sel = ae1;
+  }
+
+  inline bool IsMaxima(const Vertex& v)
+  {
+    return ((v.flags & VertexFlags::LocalMax) != VertexFlags::Empty);
+  }
+
+
+  inline bool IsMaxima(const Active& e)
+  {
+    return IsMaxima(*e.vertex_top);
+  }
+
+  inline Vertex* GetCurrYMaximaVertex_Open(const Active& e)
+  {
+    Vertex* result = e.vertex_top;
+    if (e.wind_dx > 0)
+      while ((result->next->pt.y == result->pt.y) &&
+        ((result->flags & (VertexFlags::OpenEnd |
+          VertexFlags::LocalMax)) == VertexFlags::Empty))
+            result = result->next;
+    else
+      while (result->prev->pt.y == result->pt.y &&
+        ((result->flags & (VertexFlags::OpenEnd |
+          VertexFlags::LocalMax)) == VertexFlags::Empty))
+          result = result->prev;
+    if (!IsMaxima(*result)) result = nullptr; // not a maxima
+    return result;
+  }
+
+    inline Vertex* GetCurrYMaximaVertex(const Active& e)
+  {
+    Vertex* result = e.vertex_top;
+    if (e.wind_dx > 0)
+      while (result->next->pt.y == result->pt.y) result = result->next;
+    else
+      while (result->prev->pt.y == result->pt.y) result = result->prev;
+    if (!IsMaxima(*result)) result = nullptr; // not a maxima
+    return result;
+  }
+
+  Active* GetMaximaPair(const Active& e)
+  {
+    Active* e2;
+    e2 = e.next_in_ael;
+    while (e2)
+    {
+      if (e2->vertex_top == e.vertex_top) return e2;  // Found!
+      e2 = e2->next_in_ael;
+    }
+    return nullptr;
+  }
+
+  inline int PointCount(OutPt* op)
+  {
+    OutPt* op2 = op;
+    int cnt = 0;
+    do
+    {
+      op2 = op2->next;
+      ++cnt;
+    } while (op2 != op);
+    return cnt;
+  }
+
+  inline OutPt* DuplicateOp(OutPt* op, bool insert_after)
+  {
+    OutPt* result = new OutPt(op->pt, op->outrec);
+    if (insert_after)
+    {
+      result->next = op->next;
+      result->next->prev = result;
+      result->prev = op;
+      op->next = result;
+    }
+    else
+    {
+      result->prev = op->prev;
+      result->prev->next = result;
+      result->next = op;
+      op->prev = result;
+    }
+    return result;
+  }
+
+  inline OutPt* DisposeOutPt(OutPt* op)
+  {
+    OutPt* result = op->next;
+    op->prev->next = op->next;
+    op->next->prev = op->prev;
+    delete op;
+    return result;
+  }
+
+
+  inline void DisposeOutPts(OutRec* outrec)
+  {
+    OutPt* op = outrec->pts;
+    op->prev->next = nullptr;
+    while (op)
+    {
+      OutPt* tmp = op;
+      op = op->next;
+      delete tmp;
+    };
+    outrec->pts = nullptr;
+  }
+
+
+  bool IntersectListSort(const IntersectNode& a, const IntersectNode& b)
+  {
+    //note different inequality tests ...
+    return (a.pt.y == b.pt.y) ? (a.pt.x < b.pt.x) : (a.pt.y > b.pt.y);
+  }
+
+
+  inline void SetSides(OutRec& outrec, Active& start_edge, Active& end_edge)
+  {
+    outrec.front_edge = &start_edge;
+    outrec.back_edge = &end_edge;
+  }
+
+
+  void SwapOutrecs(Active& e1, Active& e2)
+  {
+    OutRec* or1 = e1.outrec;
+    OutRec* or2 = e2.outrec;
+    if (or1 == or2)
+    {
+      Active* e = or1->front_edge;
+      or1->front_edge = or1->back_edge;
+      or1->back_edge = e;
+      return;
+    }
+    if (or1)
+    {
+      if (&e1 == or1->front_edge)
+        or1->front_edge = &e2;
+      else
+        or1->back_edge = &e2;
+    }
+    if (or2)
+    {
+      if (&e2 == or2->front_edge)
+        or2->front_edge = &e1;
+      else
+        or2->back_edge = &e1;
+    }
+    e1.outrec = or2;
+    e2.outrec = or1;
+  }
+
+
+  double Area(OutPt* op)
+  {
+    //https://en.wikipedia.org/wiki/Shoelace_formula
+    double result = 0.0;
+    OutPt* op2 = op;
+    do
+    {
+      result += static_cast<double>(op2->prev->pt.y + op2->pt.y) *
+        static_cast<double>(op2->prev->pt.x - op2->pt.x);
+      op2 = op2->next;
+    } while (op2 != op);
+    return result * 0.5;
+  }
+
+  inline double AreaTriangle(const Point64& pt1,
+    const Point64& pt2, const Point64& pt3)
+  {
+    return (static_cast<double>(pt3.y + pt1.y) * static_cast<double>(pt3.x - pt1.x) +
+      static_cast<double>(pt1.y + pt2.y) * static_cast<double>(pt1.x - pt2.x) +
+      static_cast<double>(pt2.y + pt3.y) * static_cast<double>(pt2.x - pt3.x));
+  }
+
+  void ReverseOutPts(OutPt* op)
+  {
+    if (!op) return;
+
+    OutPt* op1 = op;
+    OutPt* op2;
+
+    do
+    {
+      op2 = op1->next;
+      op1->next = op1->prev;
+      op1->prev = op2;
+      op1 = op2;
+    } while (op1 != op);
+  }
+
+  inline void SwapSides(OutRec& outrec)
+  {
+    Active* e2 = outrec.front_edge;
+    outrec.front_edge = outrec.back_edge;
+    outrec.back_edge = e2;
+    outrec.pts = outrec.pts->next;
+  }
+
+  inline OutRec* GetRealOutRec(OutRec* outrec)
+  {
+    while (outrec && !outrec->pts) outrec = outrec->owner;
+    return outrec;
+  }
+
+  inline bool IsValidOwner(OutRec* outrec, OutRec* testOwner)
+  {
+    // prevent outrec owning itself either directly or indirectly
+    while (testOwner && testOwner != outrec) testOwner = testOwner->owner;
+    return !testOwner;
+  }
+
+  inline void UncoupleOutRec(Active ae)
+  {
+    OutRec* outrec = ae.outrec;
+    if (!outrec) return;
+    outrec->front_edge->outrec = nullptr;
+    outrec->back_edge->outrec = nullptr;
+    outrec->front_edge = nullptr;
+    outrec->back_edge = nullptr;
+  }
+
+
+  inline bool PtsReallyClose(const Point64& pt1, const Point64& pt2)
+  {
+    return (std::llabs(pt1.x - pt2.x) < 2) && (std::llabs(pt1.y - pt2.y) < 2);
+  }
+
+  inline bool IsVerySmallTriangle(const OutPt& op)
+  {
+    return op.next->next == op.prev &&
+      (PtsReallyClose(op.prev->pt, op.next->pt) ||
+        PtsReallyClose(op.pt, op.next->pt) ||
+        PtsReallyClose(op.pt, op.prev->pt));
+  }
+
+  inline bool IsValidClosedPath(const OutPt* op)
+  {
+    return op && (op->next != op) && (op->next != op->prev) &&
+      !IsVerySmallTriangle(*op);
+  }
+
+  inline bool OutrecIsAscending(const Active* hotEdge)
+  {
+    return (hotEdge == hotEdge->outrec->front_edge);
+  }
+
+  inline void SwapFrontBackSides(OutRec& outrec)
+  {
+    Active* tmp = outrec.front_edge;
+    outrec.front_edge = outrec.back_edge;
+    outrec.back_edge = tmp;
+    outrec.pts = outrec.pts->next;
+  }
+
+  inline bool EdgesAdjacentInAEL(const IntersectNode& inode)
+  {
+    return (inode.edge1->next_in_ael == inode.edge2) || (inode.edge1->prev_in_ael == inode.edge2);
+  }
+
+  inline bool IsJoined(const Active& e)
+  {
+    return e.join_with != JoinWith::NoJoin;
+  }
+
+  inline void SetOwner(OutRec* outrec, OutRec* new_owner)
+  {
+    //precondition1: new_owner is never null
+    new_owner->owner = GetRealOutRec(new_owner->owner);
+    OutRec* tmp = new_owner;
+    while (tmp && tmp != outrec) tmp = tmp->owner;
+    if (tmp) new_owner->owner = outrec->owner;
+    outrec->owner = new_owner;
+  }
+
+  static PointInPolygonResult PointInOpPolygon(const Point64& pt, OutPt* op)
+  {
+    if (op == op->next || op->prev == op->next)
+      return PointInPolygonResult::IsOutside;
+
+    OutPt* op2 = op;
+    do
+    {
+      if (op->pt.y != pt.y) break;
+      op = op->next;
+    } while (op != op2);
+    if (op->pt.y == pt.y) // not a proper polygon
+      return PointInPolygonResult::IsOutside;
+
+    bool is_above = op->pt.y < pt.y, starting_above = is_above;
+    int val = 0;
+    op2 = op->next;
+    while (op2 != op)
+    {
+      if (is_above)
+        while (op2 != op && op2->pt.y < pt.y) op2 = op2->next;
+      else
+        while (op2 != op && op2->pt.y > pt.y) op2 = op2->next;
+      if (op2 == op) break;
+
+      // must have touched or crossed the pt.Y horizontal
+      // and this must happen an even number of times
+
+      if (op2->pt.y == pt.y) // touching the horizontal
+      {
+        if (op2->pt.x == pt.x || (op2->pt.y == op2->prev->pt.y &&
+          (pt.x < op2->prev->pt.x) != (pt.x < op2->pt.x)))
+          return PointInPolygonResult::IsOn;
+
+        op2 = op2->next;
+        if (op2 == op) break;
+        continue;
+      }
+
+      if (pt.x < op2->pt.x && pt.x < op2->prev->pt.x);
+      // do nothing because
+      // we're only interested in edges crossing on the left
+      else if ((pt.x > op2->prev->pt.x && pt.x > op2->pt.x))
+        val = 1 - val; // toggle val
+      else
+      {
+        int i = CrossProductSign(op2->prev->pt, op2->pt, pt);
+        if (i == 0) return PointInPolygonResult::IsOn;
+        if ((i < 0) == is_above) val = 1 - val;
+      }
+      is_above = !is_above;
+      op2 = op2->next;
+    }
+
+    if (is_above != starting_above)
+    {
+      int i = CrossProductSign(op2->prev->pt, op2->pt, pt);
+      if (i == 0) return PointInPolygonResult::IsOn;
+      if ((i < 0) == is_above) val = 1 - val;
+    }
+
+    if (val == 0) return PointInPolygonResult::IsOutside;
+    else return PointInPolygonResult::IsInside;
+  }
+
+  inline Path64 GetCleanPath(OutPt* op)
+  {
+    Path64 result;
+    OutPt* op2 = op;
+    while (op2->next != op &&
+      ((op2->pt.x == op2->next->pt.x && op2->pt.x == op2->prev->pt.x) ||
+        (op2->pt.y == op2->next->pt.y && op2->pt.y == op2->prev->pt.y))) op2 = op2->next;
+    result.emplace_back(op2->pt);
+    OutPt* prevOp = op2;
+    op2 = op2->next;
+    while (op2 != op)
+    {
+      if ((op2->pt.x != op2->next->pt.x || op2->pt.x != prevOp->pt.x) &&
+        (op2->pt.y != op2->next->pt.y || op2->pt.y != prevOp->pt.y))
+      {
+        result.emplace_back(op2->pt);
+        prevOp = op2;
+      }
+      op2 = op2->next;
+    }
+    return result;
+  }
+
+  inline bool Path2ContainsPath1(OutPt* op1, OutPt* op2)
+  {
+    // this function accommodates rounding errors that 
+    // can cause path micro intersections
+    PointInPolygonResult pip = PointInPolygonResult::IsOn;
+    OutPt* op = op1;
+    do {
+      switch (PointInOpPolygon(op->pt, op2))
+      {
+      case PointInPolygonResult::IsOutside:
+        if (pip == PointInPolygonResult::IsOutside) return false;
+        pip = PointInPolygonResult::IsOutside;
+        break;
+      case PointInPolygonResult::IsInside:
+        if (pip == PointInPolygonResult::IsInside) return true;
+        pip = PointInPolygonResult::IsInside;
+        break;
+      default: break;
+      }
+      op = op->next;
+    } while (op != op1);
+    // result unclear, so try again using cleaned paths
+    return Path2ContainsPath1(GetCleanPath(op1), GetCleanPath(op2)); // (#973)
+  }
+
+  void AddLocMin(LocalMinimaList& list,
+    Vertex& vert, PathType polytype, bool is_open)
+  {
+    //make sure the vertex is added only once ...
+    if ((VertexFlags::LocalMin & vert.flags) != VertexFlags::Empty) return;
+
+    vert.flags = (vert.flags | VertexFlags::LocalMin);
+    list.emplace_back(std::make_unique <LocalMinima>(&vert, polytype, is_open));
+  }
+
+  void AddPaths_(const Paths64& paths, PathType polytype, bool is_open,
+    std::vector<Vertex*>& vertexLists, LocalMinimaList& locMinList)
+  {
+    const auto total_vertex_count =
+      std::accumulate(paths.begin(), paths.end(), size_t(0),
+        [](const auto& a, const Path64& path)
+        {return a + path.size(); });
+    if (total_vertex_count == 0) return;
+
+    Vertex* vertices = new Vertex[total_vertex_count], * v = vertices;
+    for (const Path64& path : paths)
+    {
+      //for each path create a circular double linked list of vertices
+      Vertex* v0 = v, * curr_v = v, * prev_v = nullptr;
+
+      if (path.empty())
+        continue;
+
+      v->prev = nullptr;
+      int cnt = 0;
+      for (const Point64& pt : path)
+      {
+        if (prev_v)
+        {
+          if (prev_v->pt == pt) continue; // ie skips duplicates
+          prev_v->next = curr_v;
+        }
+        curr_v->prev = prev_v;
+        curr_v->pt = pt;
+        curr_v->flags = VertexFlags::Empty;
+        prev_v = curr_v++;
+        cnt++;
+      }
+      if (!prev_v || !prev_v->prev) continue;
+      if (!is_open && prev_v->pt == v0->pt)
+        prev_v = prev_v->prev;
+      prev_v->next = v0;
+      v0->prev = prev_v;
+      v = curr_v; // ie get ready for next path
+      if (cnt < 2 || (cnt == 2 && !is_open)) continue;
+
+      //now find and assign local minima
+      bool going_up, going_up0;
+      if (is_open)
+      {
+        curr_v = v0->next;
+        while (curr_v != v0 && curr_v->pt.y == v0->pt.y)
+          curr_v = curr_v->next;
+        going_up = curr_v->pt.y <= v0->pt.y;
+        if (going_up)
+        {
+          v0->flags = VertexFlags::OpenStart;
+          AddLocMin(locMinList , *v0, polytype, true);
+        }
+        else
+          v0->flags = VertexFlags::OpenStart | VertexFlags::LocalMax;
+      }
+      else // closed path
+      {
+        prev_v = v0->prev;
+        while (prev_v != v0 && prev_v->pt.y == v0->pt.y)
+          prev_v = prev_v->prev;
+        if (prev_v == v0)
+          continue; // only open paths can be completely flat
+        going_up = prev_v->pt.y > v0->pt.y;
+      }
+
+      going_up0 = going_up;
+      prev_v = v0;
+      curr_v = v0->next;
+      while (curr_v != v0)
+      {
+        if (curr_v->pt.y > prev_v->pt.y && going_up)
+        {
+          prev_v->flags = (prev_v->flags | VertexFlags::LocalMax);
+          going_up = false;
+        }
+        else if (curr_v->pt.y < prev_v->pt.y && !going_up)
+        {
+          going_up = true;
+          AddLocMin(locMinList, *prev_v, polytype, is_open);
+        }
+        prev_v = curr_v;
+        curr_v = curr_v->next;
+      }
+
+      if (is_open)
+      {
+        prev_v->flags = prev_v->flags | VertexFlags::OpenEnd;
+        if (going_up)
+          prev_v->flags = prev_v->flags | VertexFlags::LocalMax;
+        else
+          AddLocMin(locMinList, *prev_v, polytype, is_open);
+      }
+      else if (going_up != going_up0)
+      {
+        if (going_up0) AddLocMin(locMinList, *prev_v, polytype, false);
+        else prev_v->flags = prev_v->flags | VertexFlags::LocalMax;
+      }
+    } // end processing current path
+
+    vertexLists.emplace_back(vertices);
+  }
+
+  //------------------------------------------------------------------------------
+  // ReuseableDataContainer64 methods ...
+  //------------------------------------------------------------------------------
+
+  void ReuseableDataContainer64::AddLocMin(Vertex& vert, PathType polytype, bool is_open)
+  {
+    //make sure the vertex is added only once ...
+    if ((VertexFlags::LocalMin & vert.flags) != VertexFlags::Empty) return;
+
+    vert.flags = (vert.flags | VertexFlags::LocalMin);
+    minima_list_.emplace_back(std::make_unique <LocalMinima>(&vert, polytype, is_open));
+  }
+
+  void ReuseableDataContainer64::AddPaths(const Paths64& paths,
+    PathType polytype, bool is_open)
+  {
+    AddPaths_(paths, polytype, is_open, vertex_lists_, minima_list_);
+  }
+
+  ReuseableDataContainer64::~ReuseableDataContainer64()
+  {
+    Clear();
+  }
+
+  void ReuseableDataContainer64::Clear()
+  {
+    minima_list_.clear();
+    for (auto v : vertex_lists_) delete[] v;
+    vertex_lists_.clear();
+  }
+
+  //------------------------------------------------------------------------------
+  // ClipperBase methods ...
+  //------------------------------------------------------------------------------
+
+  ClipperBase::~ClipperBase()
+  {
+    Clear();
+  }
+
+  void ClipperBase::DeleteEdges(Active*& e)
+  {
+    while (e)
+    {
+      Active* e2 = e;
+      e = e->next_in_ael;
+      delete e2;
+    }
+  }
+
+  void ClipperBase::CleanUp()
+  {
+    DeleteEdges(actives_);
+    scanline_list_ = std::priority_queue<int64_t>();
+    intersect_nodes_.clear();
+    DisposeAllOutRecs();
+    horz_seg_list_.clear();
+    horz_join_list_.clear();
+  }
+
+
+  void ClipperBase::Clear()
+  {
+    CleanUp();
+    DisposeVerticesAndLocalMinima();
+    current_locmin_iter_ = minima_list_.begin();
+    minima_list_sorted_ = false;
+    has_open_paths_ = false;
+  }
+
+
+  void ClipperBase::Reset()
+  {
+    if (!minima_list_sorted_)
+    {
+      std::stable_sort(minima_list_.begin(), minima_list_.end(), LocMinSorter()); //#594
+      minima_list_sorted_ = true;
+    }
+    LocalMinimaList::const_reverse_iterator i;
+    for (i = minima_list_.rbegin(); i != minima_list_.rend(); ++i)
+      InsertScanline((*i)->vertex->pt.y);
+
+    current_locmin_iter_ = minima_list_.begin();
+    actives_ = nullptr;
+    sel_ = nullptr;
+    succeeded_ = true;
+  }
+
+
+#ifdef USINGZ
+  void ClipperBase::SetZ(const Active& e1, const Active& e2, Point64& ip)
+  {
+    if (!zCallback_) return;
+    // prioritize subject over clip vertices by passing
+    // subject vertices before clip vertices in the callback
+    if (GetPolyType(e1) == PathType::Subject)
+    {
+      if (ip == e1.bot) ip.z = e1.bot.z;
+      else if (ip == e1.top) ip.z = e1.top.z;
+      else if (ip == e2.bot) ip.z = e2.bot.z;
+      else if (ip == e2.top) ip.z = e2.top.z;
+      else ip.z = DefaultZ;
+      zCallback_(e1.bot, e1.top, e2.bot, e2.top, ip);
+    }
+    else
+    {
+      if (ip == e2.bot) ip.z = e2.bot.z;
+      else if (ip == e2.top) ip.z = e2.top.z;
+      else if (ip == e1.bot) ip.z = e1.bot.z;
+      else if (ip == e1.top) ip.z = e1.top.z;
+      else ip.z = DefaultZ;
+      zCallback_(e2.bot, e2.top, e1.bot, e1.top, ip);
+    }
+  }
+#endif
+
+  void ClipperBase::AddPath(const Path64& path, PathType polytype, bool is_open)
+  {
+    AddPaths(Paths64(1, path), polytype, is_open);
+  }
+
+  void ClipperBase::AddPaths(const Paths64& paths, PathType polytype, bool is_open)
+  {
+    if (is_open) has_open_paths_ = true;
+    minima_list_sorted_ = false;
+    AddPaths_(paths, polytype, is_open, vertex_lists_, minima_list_);
+  }
+
+  void ClipperBase::AddReuseableData(const ReuseableDataContainer64& reuseable_data)
+  {
+    // nb: reuseable_data will continue to own the vertices
+    // and remains responsible for their clean up.
+    succeeded_ = false;
+    minima_list_sorted_ = false;
+    LocalMinimaList::const_iterator i;
+    for (i = reuseable_data.minima_list_.cbegin(); i != reuseable_data.minima_list_.cend(); ++i)
+    {
+      minima_list_.emplace_back(std::make_unique <LocalMinima>((*i)->vertex, (*i)->polytype, (*i)->is_open));
+      if ((*i)->is_open) has_open_paths_ = true;
+    }
+  }
+
+  void ClipperBase::InsertScanline(int64_t y)
+  {
+    scanline_list_.push(y);
+  }
+
+
+  bool ClipperBase::PopScanline(int64_t& y)
+  {
+    if (scanline_list_.empty()) return false;
+    y = scanline_list_.top();
+    scanline_list_.pop();
+    while (!scanline_list_.empty() && y == scanline_list_.top())
+      scanline_list_.pop();  // Pop duplicates.
+    return true;
+  }
+
+
+  bool ClipperBase::PopLocalMinima(int64_t y, LocalMinima*& local_minima)
+  {
+    if (current_locmin_iter_ == minima_list_.end() || (*current_locmin_iter_)->vertex->pt.y != y) return false;
+    local_minima = (current_locmin_iter_++)->get();
+    return true;
+  }
+
+  void ClipperBase::DisposeAllOutRecs()
+  {
+    for (auto outrec : outrec_list_)
+    {
+      if (outrec->pts) DisposeOutPts(outrec);
+      delete outrec;
+    }
+    outrec_list_.resize(0);
+  }
+
+  void ClipperBase::DisposeVerticesAndLocalMinima()
+  {
+    minima_list_.clear();
+    for (auto v : vertex_lists_) delete[] v;
+    vertex_lists_.clear();
+  }
+
+
+  void ClipperBase::AddLocMin(Vertex& vert, PathType polytype, bool is_open)
+  {
+    //make sure the vertex is added only once ...
+    if ((VertexFlags::LocalMin & vert.flags) != VertexFlags::Empty) return;
+
+    vert.flags = (vert.flags | VertexFlags::LocalMin);
+    minima_list_.emplace_back(std::make_unique <LocalMinima>(&vert, polytype, is_open));
+  }
+
+  bool ClipperBase::IsContributingClosed(const Active& e) const
+  {
+    switch (fillrule_)
+    {
+    case FillRule::EvenOdd:
+      break;
+    case FillRule::NonZero:
+      if (abs(e.wind_cnt) != 1) return false;
+      break;
+    case FillRule::Positive:
+      if (e.wind_cnt != 1) return false;
+      break;
+    case FillRule::Negative:
+      if (e.wind_cnt != -1) return false;
+      break;
+    // Should never happen, but adding this to stop a compiler warning
+    default:
+      break;
+    }
+
+    switch (cliptype_)
+    {
+    case ClipType::NoClip:
+      return false;
+    case ClipType::Intersection:
+      switch (fillrule_)
+      {
+      case FillRule::Positive:
+        return (e.wind_cnt2 > 0);
+      case FillRule::Negative:
+        return (e.wind_cnt2 < 0);
+      default:
+        return (e.wind_cnt2 != 0);
+      }
+      break;
+
+    case ClipType::Union:
+      switch (fillrule_)
+      {
+      case FillRule::Positive:
+        return (e.wind_cnt2 <= 0);
+      case FillRule::Negative:
+        return (e.wind_cnt2 >= 0);
+      default:
+        return (e.wind_cnt2 == 0);
+      }
+      break;
+
+    case ClipType::Difference:
+      bool result;
+      switch (fillrule_)
+      {
+      case FillRule::Positive:
+        result = (e.wind_cnt2 <= 0);
+        break;
+      case FillRule::Negative:
+        result = (e.wind_cnt2 >= 0);
+        break;
+      default:
+        result = (e.wind_cnt2 == 0);
+      }
+      if (GetPolyType(e) == PathType::Subject)
+        return result;
+      else
+        return !result;
+      break;
+
+    case ClipType::Xor: return true;  break;
+    // Should never happen, but adding this to stop a compiler warning
+    default:
+      break;
+    }
+    return false;  // we should never get here
+  }
+
+
+  inline bool ClipperBase::IsContributingOpen(const Active& e) const
+  {
+    bool is_in_clip, is_in_subj;
+    switch (fillrule_)
+    {
+    case FillRule::Positive:
+      is_in_clip = e.wind_cnt2 > 0;
+      is_in_subj = e.wind_cnt > 0;
+      break;
+    case FillRule::Negative:
+      is_in_clip = e.wind_cnt2 < 0;
+      is_in_subj = e.wind_cnt < 0;
+      break;
+    default:
+      is_in_clip = e.wind_cnt2 != 0;
+      is_in_subj = e.wind_cnt != 0;
+    }
+
+    switch (cliptype_)
+    {
+    case ClipType::Intersection: return is_in_clip;
+    case ClipType::Union: return (!is_in_subj && !is_in_clip);
+    default: return !is_in_clip;
+    }
+  }
+
+
+  void ClipperBase::SetWindCountForClosedPathEdge(Active& e)
+  {
+    //Wind counts refer to polygon regions not edges, so here an edge's WindCnt
+    //indicates the higher of the wind counts for the two regions touching the
+    //edge. (NB Adjacent regions can only ever have their wind counts differ by
+    //one. Also, open paths have no meaningful wind directions or counts.)
+
+    Active* e2 = e.prev_in_ael;
+    //find the nearest closed path edge of the same PolyType in AEL (heading left)
+    PathType pt = GetPolyType(e);
+    while (e2 && (GetPolyType(*e2) != pt || IsOpen(*e2))) e2 = e2->prev_in_ael;
+
+    if (!e2)
+    {
+      e.wind_cnt = e.wind_dx;
+      e2 = actives_;
+    }
+    else if (fillrule_ == FillRule::EvenOdd)
+    {
+      e.wind_cnt = e.wind_dx;
+      e.wind_cnt2 = e2->wind_cnt2;
+      e2 = e2->next_in_ael;
+    }
+    else
+    {
+      //NonZero, positive, or negative filling here ...
+      //if e's WindCnt is in the SAME direction as its WindDx, then polygon
+      //filling will be on the right of 'e'.
+      //NB neither e2.WindCnt nor e2.WindDx should ever be 0.
+      if (e2->wind_cnt * e2->wind_dx < 0)
+      {
+        //opposite directions so 'e' is outside 'e2' ...
+        if (abs(e2->wind_cnt) > 1)
+        {
+          //outside prev poly but still inside another.
+          if (e2->wind_dx * e.wind_dx < 0)
+            //reversing direction so use the same WC
+            e.wind_cnt = e2->wind_cnt;
+          else
+            //otherwise keep 'reducing' the WC by 1 (ie towards 0) ...
+            e.wind_cnt = e2->wind_cnt + e.wind_dx;
+        }
+        else
+          //now outside all polys of same polytype so set own WC ...
+          e.wind_cnt = (IsOpen(e) ? 1 : e.wind_dx);
+      }
+      else
+      {
+        //'e' must be inside 'e2'
+        if (e2->wind_dx * e.wind_dx < 0)
+          //reversing direction so use the same WC
+          e.wind_cnt = e2->wind_cnt;
+        else
+          //otherwise keep 'increasing' the WC by 1 (ie away from 0) ...
+          e.wind_cnt = e2->wind_cnt + e.wind_dx;
+      }
+      e.wind_cnt2 = e2->wind_cnt2;
+      e2 = e2->next_in_ael;  // ie get ready to calc WindCnt2
+    }
+
+    //update wind_cnt2 ...
+    if (fillrule_ == FillRule::EvenOdd)
+      while (e2 != &e)
+      {
+        if (GetPolyType(*e2) != pt && !IsOpen(*e2))
+          e.wind_cnt2 = (e.wind_cnt2 == 0 ? 1 : 0);
+        e2 = e2->next_in_ael;
+      }
+    else
+      while (e2 != &e)
+      {
+        if (GetPolyType(*e2) != pt && !IsOpen(*e2))
+          e.wind_cnt2 += e2->wind_dx;
+        e2 = e2->next_in_ael;
+      }
+  }
+
+
+  void ClipperBase::SetWindCountForOpenPathEdge(Active& e)
+  {
+    Active* e2 = actives_;
+    if (fillrule_ == FillRule::EvenOdd)
+    {
+      int cnt1 = 0, cnt2 = 0;
+      while (e2 != &e)
+      {
+        if (GetPolyType(*e2) == PathType::Clip)
+          cnt2++;
+        else if (!IsOpen(*e2))
+          cnt1++;
+        e2 = e2->next_in_ael;
+      }
+      e.wind_cnt = (IsOdd(cnt1) ? 1 : 0);
+      e.wind_cnt2 = (IsOdd(cnt2) ? 1 : 0);
+    }
+    else
+    {
+      while (e2 != &e)
+      {
+        if (GetPolyType(*e2) == PathType::Clip)
+          e.wind_cnt2 += e2->wind_dx;
+        else if (!IsOpen(*e2))
+          e.wind_cnt += e2->wind_dx;
+        e2 = e2->next_in_ael;
+      }
+    }
+  }
+
+  bool IsValidAelOrder(const Active& resident, const Active& newcomer)
+  {
+    if (newcomer.curr_x != resident.curr_x)
+        return newcomer.curr_x > resident.curr_x;
+
+    //get the turning direction  a1.top, a2.bot, a2.top
+    int i = CrossProductSign(resident.top, newcomer.bot, newcomer.top);
+    if (i != 0) return i < 0;
+
+    //edges must be collinear to get here
+    //for starting open paths, place them according to
+    //the direction they're about to turn
+    if (!IsMaxima(resident) && (resident.top.y > newcomer.top.y))
+    {
+      return (CrossProductSign(newcomer.bot, resident.top, NextVertex(resident)->pt) <= 0);
+    }
+    else if (!IsMaxima(newcomer) && (newcomer.top.y > resident.top.y))
+    {
+      return (CrossProductSign(newcomer.bot, newcomer.top, NextVertex(newcomer)->pt) >= 0);
+    }
+
+    int64_t y = newcomer.bot.y;
+    bool newcomerIsLeft = newcomer.is_left_bound;
+
+    if (resident.bot.y != y || resident.local_min->vertex->pt.y != y)
+      return newcomer.is_left_bound;
+    //resident must also have just been inserted
+    else if (resident.is_left_bound != newcomerIsLeft)
+      return newcomerIsLeft;
+    else if (IsCollinear(PrevPrevVertex(resident)->pt,
+      resident.bot, resident.top)) return true;
+    else
+      //compare turning direction of the alternate bound
+      return (CrossProductSign(PrevPrevVertex(resident)->pt,
+        newcomer.bot, PrevPrevVertex(newcomer)->pt) > 0) == newcomerIsLeft;
+  }
+
+
+  void ClipperBase::InsertLeftEdge(Active& e)
+  {
+    Active* e2;
+    if (!actives_)
+    {
+      e.prev_in_ael = nullptr;
+      e.next_in_ael = nullptr;
+      actives_ = &e;
+    }
+    else if (!IsValidAelOrder(*actives_, e))
+    {
+      e.prev_in_ael = nullptr;
+      e.next_in_ael = actives_;
+      actives_->prev_in_ael = &e;
+      actives_ = &e;
+    }
+    else
+    {
+      e2 = actives_;
+      while (e2->next_in_ael && IsValidAelOrder(*e2->next_in_ael, e))
+        e2 = e2->next_in_ael;
+      if (e2->join_with == JoinWith::Right)
+        e2 = e2->next_in_ael;
+      if (!e2) return; // should never happen and stops compiler warning :)
+      e.next_in_ael = e2->next_in_ael;
+      if (e2->next_in_ael) e2->next_in_ael->prev_in_ael = &e;
+      e.prev_in_ael = e2;
+      e2->next_in_ael = &e;
+    }
+  }
+
+
+  void InsertRightEdge(Active& e, Active& e2)
+  {
+    e2.next_in_ael = e.next_in_ael;
+    if (e.next_in_ael) e.next_in_ael->prev_in_ael = &e2;
+    e2.prev_in_ael = &e;
+    e.next_in_ael = &e2;
+  }
+
+
+  void ClipperBase::InsertLocalMinimaIntoAEL(int64_t bot_y)
+  {
+    LocalMinima* local_minima;
+    Active* left_bound, * right_bound;
+    //Add any local minima (if any) at BotY ...
+    //nb: horizontal local minima edges should contain locMin.vertex.prev
+
+    while (PopLocalMinima(bot_y, local_minima))
+    {
+      if ((local_minima->vertex->flags & VertexFlags::OpenStart) != VertexFlags::Empty)
+      {
+        left_bound = nullptr;
+      }
+      else
+      {
+        left_bound = new Active();
+        left_bound->bot = local_minima->vertex->pt;
+        left_bound->curr_x = left_bound->bot.x;
+        left_bound->wind_dx = -1;
+        left_bound->vertex_top = local_minima->vertex->prev;  // ie descending
+        left_bound->top = left_bound->vertex_top->pt;
+        left_bound->local_min = local_minima;
+        SetDx(*left_bound);
+      }
+
+      if ((local_minima->vertex->flags & VertexFlags::OpenEnd) != VertexFlags::Empty)
+      {
+        right_bound = nullptr;
+      }
+      else
+      {
+        right_bound = new Active();
+        right_bound->bot = local_minima->vertex->pt;
+        right_bound->curr_x = right_bound->bot.x;
+        right_bound->wind_dx = 1;
+        right_bound->vertex_top = local_minima->vertex->next;  // ie ascending
+        right_bound->top = right_bound->vertex_top->pt;
+        right_bound->local_min = local_minima;
+        SetDx(*right_bound);
+      }
+
+      //Currently LeftB is just the descending bound and RightB is the ascending.
+      //Now if the LeftB isn't on the left of RightB then we need swap them.
+      if (left_bound && right_bound)
+      {
+        if (IsHorizontal(*left_bound))
+        {
+          if (IsHeadingRightHorz(*left_bound)) SwapActives(left_bound, right_bound);
+        }
+        else if (IsHorizontal(*right_bound))
+        {
+          if (IsHeadingLeftHorz(*right_bound)) SwapActives(left_bound, right_bound);
+        }
+        else if (left_bound->dx < right_bound->dx)
+          SwapActives(left_bound, right_bound);
+      }
+      else if (!left_bound)
+      {
+        left_bound = right_bound;
+        right_bound = nullptr;
+      }
+
+      bool contributing;
+      left_bound->is_left_bound = true;
+      InsertLeftEdge(*left_bound);
+
+      if (IsOpen(*left_bound))
+      {
+        SetWindCountForOpenPathEdge(*left_bound);
+        contributing = IsContributingOpen(*left_bound);
+      }
+      else
+      {
+        SetWindCountForClosedPathEdge(*left_bound);
+        contributing = IsContributingClosed(*left_bound);
+      }
+
+      if (right_bound)
+      {
+        right_bound->is_left_bound = false;
+        right_bound->wind_cnt = left_bound->wind_cnt;
+        right_bound->wind_cnt2 = left_bound->wind_cnt2;
+        InsertRightEdge(*left_bound, *right_bound);  ///////
+        if (contributing)
+        {
+          AddLocalMinPoly(*left_bound, *right_bound, left_bound->bot, true);
+          if (!IsHorizontal(*left_bound))
+            CheckJoinLeft(*left_bound, left_bound->bot);
+        }
+
+        while (right_bound->next_in_ael &&
+          IsValidAelOrder(*right_bound->next_in_ael, *right_bound))
+        {
+          IntersectEdges(*right_bound, *right_bound->next_in_ael, right_bound->bot);
+          SwapPositionsInAEL(*right_bound, *right_bound->next_in_ael);
+        }
+
+        if (IsHorizontal(*right_bound))
+          PushHorz(*right_bound);
+        else
+        {
+          CheckJoinRight(*right_bound, right_bound->bot);
+          InsertScanline(right_bound->top.y);
+        }
+      }
+      else if (contributing)
+      {
+        StartOpenPath(*left_bound, left_bound->bot);
+      }
+
+      if (IsHorizontal(*left_bound))
+        PushHorz(*left_bound);
+      else
+        InsertScanline(left_bound->top.y);
+    }  // while (PopLocalMinima())
+  }
+
+
+  inline void ClipperBase::PushHorz(Active& e)
+  {
+    e.next_in_sel = (sel_ ? sel_ : nullptr);
+    sel_ = &e;
+  }
+
+
+  inline bool ClipperBase::PopHorz(Active*& e)
+  {
+    e = sel_;
+    if (!e) return false;
+    sel_ = sel_->next_in_sel;
+    return true;
+  }
+
+
+  OutPt* ClipperBase::AddLocalMinPoly(Active& e1, Active& e2,
+    const Point64& pt, bool is_new)
+  {
+    OutRec* outrec = NewOutRec();
+    e1.outrec = outrec;
+    e2.outrec = outrec;
+
+    if (IsOpen(e1))
+    {
+      outrec->owner = nullptr;
+      outrec->is_open = true;
+      if (e1.wind_dx > 0)
+        SetSides(*outrec, e1, e2);
+      else
+        SetSides(*outrec, e2, e1);
+    }
+    else
+    {
+      Active* prevHotEdge = GetPrevHotEdge(e1);
+      //e.windDx is the winding direction of the **input** paths
+      //and unrelated to the winding direction of output polygons.
+      //Output orientation is determined by e.outrec.frontE which is
+      //the ascending edge (see AddLocalMinPoly).
+      if (prevHotEdge)
+      {
+        if (using_polytree_)
+          SetOwner(outrec, prevHotEdge->outrec);
+        if (OutrecIsAscending(prevHotEdge) == is_new)
+          SetSides(*outrec, e2, e1);
+        else
+          SetSides(*outrec, e1, e2);
+      }
+      else
+      {
+        outrec->owner = nullptr;
+        if (is_new)
+          SetSides(*outrec, e1, e2);
+        else
+          SetSides(*outrec, e2, e1);
+      }
+    }
+
+    OutPt* op = new OutPt(pt, outrec);
+    outrec->pts = op;
+    return op;
+  }
+
+
+  OutPt* ClipperBase::AddLocalMaxPoly(Active& e1, Active& e2, const Point64& pt)
+  {
+    if (IsJoined(e1)) Split(e1, pt);
+    if (IsJoined(e2)) Split(e2, pt);
+
+    if (IsFront(e1) == IsFront(e2))
+    {
+      if (IsOpenEnd(e1))
+        SwapFrontBackSides(*e1.outrec);
+      else if (IsOpenEnd(e2))
+        SwapFrontBackSides(*e2.outrec);
+      else
+      {
+        succeeded_ = false;
+        return nullptr;
+      }
+    }
+
+    OutPt* result = AddOutPt(e1, pt);
+    if (e1.outrec == e2.outrec)
+    {
+      OutRec& outrec = *e1.outrec;
+      outrec.pts = result;
+
+      if (using_polytree_)
+      {
+        Active* e = GetPrevHotEdge(e1);
+        if (!e)
+          outrec.owner = nullptr;
+        else
+          SetOwner(&outrec, e->outrec);
+        // nb: outRec.owner here is likely NOT the real
+        // owner but this will be checked in RecursiveCheckOwners()
+      }
+
+      UncoupleOutRec(e1);
+      result = outrec.pts;
+      if (outrec.owner && !outrec.owner->front_edge)
+        outrec.owner = GetRealOutRec(outrec.owner);
+    }
+    //and to preserve the winding orientation of outrec ...
+    else if (IsOpen(e1))
+    {
+      if (e1.wind_dx < 0)
+        JoinOutrecPaths(e1, e2);
+      else
+        JoinOutrecPaths(e2, e1);
+    }
+    else if (e1.outrec->idx < e2.outrec->idx)
+      JoinOutrecPaths(e1, e2);
+    else
+      JoinOutrecPaths(e2, e1);
+    return result;
+  }
+
+  void ClipperBase::JoinOutrecPaths(Active& e1, Active& e2)
+  {
+    //join e2 outrec path onto e1 outrec path and then delete e2 outrec path
+    //pointers. (NB Only very rarely do the joining ends share the same coords.)
+    OutPt* p1_st = e1.outrec->pts;
+    OutPt* p2_st = e2.outrec->pts;
+    OutPt* p1_end = p1_st->next;
+    OutPt* p2_end = p2_st->next;
+    if (IsFront(e1))
+    {
+      p2_end->prev = p1_st;
+      p1_st->next = p2_end;
+      p2_st->next = p1_end;
+      p1_end->prev = p2_st;
+      e1.outrec->pts = p2_st;
+      e1.outrec->front_edge = e2.outrec->front_edge;
+      if (e1.outrec->front_edge)
+        e1.outrec->front_edge->outrec = e1.outrec;
+    }
+    else
+    {
+      p1_end->prev = p2_st;
+      p2_st->next = p1_end;
+      p1_st->next = p2_end;
+      p2_end->prev = p1_st;
+      e1.outrec->back_edge = e2.outrec->back_edge;
+      if (e1.outrec->back_edge)
+        e1.outrec->back_edge->outrec = e1.outrec;
+    }
+
+    //after joining, the e2.OutRec must contains no vertices ...
+    e2.outrec->front_edge = nullptr;
+    e2.outrec->back_edge = nullptr;
+    e2.outrec->pts = nullptr;
+
+    if (IsOpenEnd(e1))
+    {
+      e2.outrec->pts = e1.outrec->pts;
+      e1.outrec->pts = nullptr;
+    }
+    else
+      SetOwner(e2.outrec, e1.outrec);
+
+    //and e1 and e2 are maxima and are about to be dropped from the Actives list.
+    e1.outrec = nullptr;
+    e2.outrec = nullptr;
+  }
+
+  OutRec* ClipperBase::NewOutRec()
+  {
+    OutRec* result = new OutRec();
+    result->idx = outrec_list_.size();
+    outrec_list_.emplace_back(result);
+    result->pts = nullptr;
+    result->owner = nullptr;
+    result->polypath = nullptr;
+    result->is_open = false;
+    result->splits = nullptr;
+    return result;
+  }
+
+
+  OutPt* ClipperBase::AddOutPt(const Active& e, const Point64& pt)
+  {
+    OutPt* new_op = nullptr;
+
+    //Outrec.OutPts: a circular doubly-linked-list of POutPt where ...
+    //op_front[.Prev]* ~~~> op_back & op_back == op_front.Next
+    OutRec* outrec = e.outrec;
+    bool to_front = IsFront(e);
+    OutPt* op_front = outrec->pts;
+    OutPt* op_back = op_front->next;
+
+    if (to_front)
+    {
+      if (pt == op_front->pt)
+        return op_front;
+    }
+    else if (pt == op_back->pt)
+      return op_back;
+
+    new_op = new OutPt(pt, outrec);
+    op_back->prev = new_op;
+    new_op->prev = op_front;
+    new_op->next = op_back;
+    op_front->next = new_op;
+    if (to_front) outrec->pts = new_op;
+    return new_op;
+  }
+
+  void ClipperBase::CleanCollinear(OutRec* outrec)
+  {
+    outrec = GetRealOutRec(outrec);
+    if (!outrec || outrec->is_open) return;
+    if (!IsValidClosedPath(outrec->pts))
+    {
+      DisposeOutPts(outrec);
+      return;
+    }
+
+    OutPt* startOp = outrec->pts, * op2 = startOp;
+    for (; ; )
+    {
+      //NB if preserveCollinear == true, then only remove 180 deg. spikes
+      if (IsCollinear(op2->prev->pt, op2->pt, op2->next->pt) &&
+        (op2->pt == op2->prev->pt ||
+          op2->pt == op2->next->pt || !preserve_collinear_ ||
+          DotProduct(op2->prev->pt, op2->pt, op2->next->pt) < 0))
+      {
+
+        if (op2 == outrec->pts) outrec->pts = op2->prev;
+
+        op2 = DisposeOutPt(op2);
+        if (!IsValidClosedPath(op2))
+        {
+          DisposeOutPts(outrec);
+          return;
+        }
+        startOp = op2;
+        continue;
+      }
+      op2 = op2->next;
+      if (op2 == startOp) break;
+    }
+    FixSelfIntersects(outrec);
+  }
+
+  void ClipperBase::DoSplitOp (OutRec* outrec, OutPt* splitOp)
+  {
+    // splitOp.prev -> splitOp &&
+    // splitOp.next -> splitOp.next.next are intersecting
+    OutPt* prevOp = splitOp->prev;
+    OutPt* nextNextOp = splitOp->next->next;
+    outrec->pts = prevOp;
+
+    Point64 ip;
+    GetSegmentIntersectPt(prevOp->pt, splitOp->pt,
+      splitOp->next->pt, nextNextOp->pt, ip);
+
+#ifdef USINGZ
+    if (zCallback_) zCallback_(prevOp->pt, splitOp->pt,
+      splitOp->next->pt, nextNextOp->pt, ip);
+#endif
+    double area1 = Area(outrec->pts);
+    double absArea1 = std::fabs(area1);
+    if (absArea1 < 2)
+    {
+      DisposeOutPts(outrec);
+      return;
+    }
+
+    double area2 = AreaTriangle(ip, splitOp->pt, splitOp->next->pt);
+    double absArea2 = std::fabs(area2);
+
+    // de-link splitOp and splitOp.next from the path
+    // while inserting the intersection point
+    if (ip == prevOp->pt || ip == nextNextOp->pt)
+    {
+      nextNextOp->prev = prevOp;
+      prevOp->next = nextNextOp;
+    }
+    else
+    {
+      OutPt* newOp2 = new OutPt(ip, prevOp->outrec);
+      newOp2->prev = prevOp;
+      newOp2->next = nextNextOp;
+      nextNextOp->prev = newOp2;
+      prevOp->next = newOp2;
+    }
+
+    // area1 is the path's area *before* splitting, whereas area2 is
+    // the area of the triangle containing splitOp & splitOp.next.
+    // So the only way for these areas to have the same sign is if
+    // the split triangle is larger than the path containing prevOp or
+    // if there's more than one self-intersection.
+    if (absArea2 >= 1 &&
+      (absArea2 > absArea1 || (area2 > 0) == (area1 > 0)))
+    {
+      OutRec* newOr = NewOutRec();
+      newOr->owner = outrec->owner;
+
+      splitOp->outrec = newOr;
+      splitOp->next->outrec = newOr;
+      OutPt* newOp = new OutPt(ip, newOr);
+      newOp->prev = splitOp->next;
+      newOp->next = splitOp;
+      newOr->pts = newOp;
+      splitOp->prev = newOp;
+      splitOp->next->next = newOp;
+
+      if (using_polytree_)
+      {
+        if (Path2ContainsPath1(prevOp, newOp))
+        {
+          newOr->splits = new OutRecList();
+          newOr->splits->emplace_back(outrec);
+        }
+        else
+        {
+          if (!outrec->splits) outrec->splits = new OutRecList();
+          outrec->splits->emplace_back(newOr);
+        }
+      }
+    }
+    else
+    {
+      delete splitOp->next;
+      delete splitOp;
+    }
+  }
+
+  void ClipperBase::FixSelfIntersects(OutRec* outrec)
+  {
+    OutPt* op2 = outrec->pts;
+    if (op2->prev == op2->next->next) 
+      return; // because triangles can't self-intersect
+    for (; ; )
+    {
+      if (SegmentsIntersect(op2->prev->pt,
+        op2->pt, op2->next->pt, op2->next->next->pt))
+      {
+        if (SegmentsIntersect(op2->prev->pt,
+          op2->pt, op2->next->next->pt, op2->next->next->next->pt))
+        {
+          // adjacent intersections (ie a micro self-intersections)
+          op2 = DuplicateOp(op2, false);
+          op2->pt = op2->next->next->next->pt;
+          op2 = op2->next;
+        }
+        else
+        {
+          if (op2 == outrec->pts || op2->next == outrec->pts)
+            outrec->pts = outrec->pts->prev;
+          DoSplitOp(outrec, op2);
+          if (!outrec->pts) break;
+          op2 = outrec->pts;
+          if (op2->prev == op2->next->next)
+            break; // again, because triangles can't self-intersect
+          continue;
+        }
+      }
+      else
+        op2 = op2->next;
+
+      if (op2 == outrec->pts) break;
+    }
+  }
+
+
+  inline void UpdateOutrecOwner(OutRec* outrec)
+  {
+    OutPt* opCurr = outrec->pts;
+    for (; ; )
+    {
+      opCurr->outrec = outrec;
+      opCurr = opCurr->next;
+      if (opCurr == outrec->pts) return;
+    }
+  }
+
+
+  OutPt* ClipperBase::StartOpenPath(Active& e, const Point64& pt)
+  {
+    OutRec* outrec = NewOutRec();
+    outrec->is_open = true;
+
+    if (e.wind_dx > 0)
+    {
+      outrec->front_edge = &e;
+      outrec->back_edge = nullptr;
+    }
+    else
+    {
+      outrec->front_edge = nullptr;
+      outrec->back_edge = &e;
+    }
+
+    e.outrec = outrec;
+
+    OutPt* op = new OutPt(pt, outrec);
+    outrec->pts = op;
+    return op;
+  }
+
+  inline void TrimHorz(Active& horzEdge, bool preserveCollinear)
+  {
+    bool wasTrimmed = false;
+    Point64 pt = NextVertex(horzEdge)->pt;
+    while (pt.y == horzEdge.top.y)
+    {
+      //always trim 180 deg. spikes (in closed paths)
+      //but otherwise break if preserveCollinear = true
+      if (preserveCollinear &&
+        ((pt.x < horzEdge.top.x) != (horzEdge.bot.x < horzEdge.top.x)))
+        break;
+
+      horzEdge.vertex_top = NextVertex(horzEdge);
+      horzEdge.top = pt;
+      wasTrimmed = true;
+      if (IsMaxima(horzEdge)) break;
+      pt = NextVertex(horzEdge)->pt;
+    }
+
+    if (wasTrimmed) SetDx(horzEdge); // +/-infinity
+  }
+
+
+  inline void ClipperBase::UpdateEdgeIntoAEL(Active* e)
+  {
+    e->bot = e->top;
+    e->vertex_top = NextVertex(*e);
+    e->top = e->vertex_top->pt;
+    e->curr_x = e->bot.x;
+    SetDx(*e);
+
+    if (IsJoined(*e)) Split(*e, e->bot);
+
+    if (IsHorizontal(*e))
+    {
+      if (!IsOpen(*e)) TrimHorz(*e, preserve_collinear_);
+      return;
+    }
+
+    InsertScanline(e->top.y);
+    CheckJoinLeft(*e, e->bot);
+    CheckJoinRight(*e, e->bot, true); // (#500)
+  }
+
+  Active* FindEdgeWithMatchingLocMin(Active* e)
+  {
+    Active* result = e->next_in_ael;
+    while (result)
+    {
+      if (result->local_min == e->local_min) return result;
+      else if (!IsHorizontal(*result) && e->bot != result->bot) result = nullptr;
+      else result = result->next_in_ael;
+    }
+    result = e->prev_in_ael;
+    while (result)
+    {
+      if (result->local_min == e->local_min) return result;
+      else if (!IsHorizontal(*result) && e->bot != result->bot) return nullptr;
+      else result = result->prev_in_ael;
+    }
+    return result;
+  }
+
+
+  void ClipperBase::IntersectEdges(Active& e1, Active& e2, const Point64& pt)
+  {
+    //MANAGE OPEN PATH INTERSECTIONS SEPARATELY ...
+    if (has_open_paths_ && (IsOpen(e1) || IsOpen(e2)))
+    {
+      if (IsOpen(e1) && IsOpen(e2)) return;
+      Active* edge_o, * edge_c;
+      if (IsOpen(e1))
+      {
+        edge_o = &e1;
+        edge_c = &e2;
+      }
+      else
+      {
+        edge_o = &e2;
+        edge_c = &e1;
+      }
+      if (IsJoined(*edge_c)) Split(*edge_c, pt); // needed for safety
+
+      if (abs(edge_c->wind_cnt) != 1) return;
+      switch (cliptype_)
+      {
+      case ClipType::Union:
+        if (!IsHotEdge(*edge_c)) return;
+        break;
+      default:
+        if (edge_c->local_min->polytype == PathType::Subject)
+          return;
+      }
+
+      switch (fillrule_)
+      {
+      case FillRule::Positive: 
+        if (edge_c->wind_cnt != 1) return; 
+        break;
+      case FillRule::Negative: 
+        if (edge_c->wind_cnt != -1) return; 
+        break;
+      default: 
+        if (std::abs(edge_c->wind_cnt) != 1) return; 
+      }
+
+#ifdef USINGZ
+      OutPt* resultOp;
+#endif
+      //toggle contribution ...
+      if (IsHotEdge(*edge_o))
+      {
+#ifdef USINGZ
+        resultOp = AddOutPt(*edge_o, pt);
+#else
+        AddOutPt(*edge_o, pt);
+#endif
+        if (IsFront(*edge_o)) edge_o->outrec->front_edge = nullptr;
+        else edge_o->outrec->back_edge = nullptr;
+        edge_o->outrec = nullptr;
+      }
+
+      //horizontal edges can pass under open paths at a LocMins
+      else if (pt == edge_o->local_min->vertex->pt &&
+        !IsOpenEnd(*edge_o->local_min->vertex))
+      {
+        //find the other side of the LocMin and
+        //if it's 'hot' join up with it ...
+        Active* e3 = FindEdgeWithMatchingLocMin(edge_o);
+        if (e3 && IsHotEdge(*e3))
+        {
+          edge_o->outrec = e3->outrec;
+          if (edge_o->wind_dx > 0)
+            SetSides(*e3->outrec, *edge_o, *e3);
+          else
+            SetSides(*e3->outrec, *e3, *edge_o);
+          return;
+        }
+        else
+#ifdef USINGZ
+          resultOp = StartOpenPath(*edge_o, pt);
+#else
+          StartOpenPath(*edge_o, pt);
+#endif
+      }
+      else
+#ifdef USINGZ
+        resultOp = StartOpenPath(*edge_o, pt);
+#else
+        StartOpenPath(*edge_o, pt);
+#endif
+
+#ifdef USINGZ
+      if (zCallback_) SetZ(*edge_o, *edge_c, resultOp->pt);
+#endif
+      return;
+    } // end of an open path intersection
+
+    //MANAGING CLOSED PATHS FROM HERE ON
+
+    if (IsJoined(e1)) Split(e1, pt);
+    if (IsJoined(e2)) Split(e2, pt);
+
+    //UPDATE WINDING COUNTS...
+
+    int old_e1_windcnt, old_e2_windcnt;
+    if (e1.local_min->polytype == e2.local_min->polytype)
+    {
+      if (fillrule_ == FillRule::EvenOdd)
+      {
+        old_e1_windcnt = e1.wind_cnt;
+        e1.wind_cnt = e2.wind_cnt;
+        e2.wind_cnt = old_e1_windcnt;
+      }
+      else
+      {
+        if (e1.wind_cnt + e2.wind_dx == 0)
+          e1.wind_cnt = -e1.wind_cnt;
+        else
+          e1.wind_cnt += e2.wind_dx;
+        if (e2.wind_cnt - e1.wind_dx == 0)
+          e2.wind_cnt = -e2.wind_cnt;
+        else
+          e2.wind_cnt -= e1.wind_dx;
+      }
+    }
+    else
+    {
+      if (fillrule_ != FillRule::EvenOdd)
+      {
+        e1.wind_cnt2 += e2.wind_dx;
+        e2.wind_cnt2 -= e1.wind_dx;
+      }
+      else
+      {
+        e1.wind_cnt2 = (e1.wind_cnt2 == 0 ? 1 : 0);
+        e2.wind_cnt2 = (e2.wind_cnt2 == 0 ? 1 : 0);
+      }
+    }
+
+    switch (fillrule_)
+    {
+    case FillRule::EvenOdd:
+    case FillRule::NonZero:
+      old_e1_windcnt = abs(e1.wind_cnt);
+      old_e2_windcnt = abs(e2.wind_cnt);
+      break;
+    default:
+      if (fillrule_ == fillpos)
+      {
+        old_e1_windcnt = e1.wind_cnt;
+        old_e2_windcnt = e2.wind_cnt;
+      }
+      else
+      {
+        old_e1_windcnt = -e1.wind_cnt;
+        old_e2_windcnt = -e2.wind_cnt;
+      }
+      break;
+    }
+
+    const bool e1_windcnt_in_01 = old_e1_windcnt == 0 || old_e1_windcnt == 1;
+    const bool e2_windcnt_in_01 = old_e2_windcnt == 0 || old_e2_windcnt == 1;
+
+    if ((!IsHotEdge(e1) && !e1_windcnt_in_01) || 
+      (!IsHotEdge(e2) && !e2_windcnt_in_01))
+        return;
+
+    //NOW PROCESS THE INTERSECTION ...
+#ifdef USINGZ
+    OutPt* resultOp = nullptr;
+#endif
+    //if both edges are 'hot' ...
+    if (IsHotEdge(e1) && IsHotEdge(e2))
+    {
+      if ((old_e1_windcnt != 0 && old_e1_windcnt != 1) || (old_e2_windcnt != 0 && old_e2_windcnt != 1) ||
+        (e1.local_min->polytype != e2.local_min->polytype && cliptype_ != ClipType::Xor))
+      {
+#ifdef USINGZ
+        resultOp = AddLocalMaxPoly(e1, e2, pt);
+        if (zCallback_ && resultOp) SetZ(e1, e2, resultOp->pt);
+#else
+        AddLocalMaxPoly(e1, e2, pt);
+#endif
+      }
+      else if (IsFront(e1) || (e1.outrec == e2.outrec))
+      {
+        //this 'else if' condition isn't strictly needed but
+        //it's sensible to split polygons that only touch at
+        //a common vertex (not at common edges).
+
+#ifdef USINGZ
+        resultOp = AddLocalMaxPoly(e1, e2, pt);
+        OutPt* op2 = AddLocalMinPoly(e1, e2, pt);
+        if (zCallback_ && resultOp) SetZ(e1, e2, resultOp->pt);
+        if (zCallback_) SetZ(e1, e2, op2->pt);
+#else
+        AddLocalMaxPoly(e1, e2, pt);
+        AddLocalMinPoly(e1, e2, pt);
+#endif
+      }
+      else
+      {
+#ifdef USINGZ
+        resultOp = AddOutPt(e1, pt);
+        OutPt* op2 = AddOutPt(e2, pt);
+        if (zCallback_)
+        {
+          SetZ(e1, e2, resultOp->pt);
+          SetZ(e1, e2, op2->pt);
+        }
+#else
+        AddOutPt(e1, pt);
+        AddOutPt(e2, pt);
+#endif
+        SwapOutrecs(e1, e2);
+      }
+    }
+    else if (IsHotEdge(e1))
+    {
+#ifdef USINGZ
+      resultOp = AddOutPt(e1, pt);
+      if (zCallback_) SetZ(e1, e2, resultOp->pt);
+#else
+      AddOutPt(e1, pt);
+#endif
+      SwapOutrecs(e1, e2);
+    }
+    else if (IsHotEdge(e2))
+    {
+#ifdef USINGZ
+      resultOp = AddOutPt(e2, pt);
+      if (zCallback_) SetZ(e1, e2, resultOp->pt);
+#else
+      AddOutPt(e2, pt);
+#endif
+      SwapOutrecs(e1, e2);
+    }
+    else
+    {
+      int64_t e1Wc2, e2Wc2;
+      switch (fillrule_)
+      {
+      case FillRule::EvenOdd:
+      case FillRule::NonZero:
+        e1Wc2 = abs(e1.wind_cnt2);
+        e2Wc2 = abs(e2.wind_cnt2);
+        break;
+      default:
+        if (fillrule_ == fillpos)
+        {
+          e1Wc2 = e1.wind_cnt2;
+          e2Wc2 = e2.wind_cnt2;
+        }
+        else
+        {
+          e1Wc2 = -e1.wind_cnt2;
+          e2Wc2 = -e2.wind_cnt2;
+        }
+        break;
+      }
+
+      if (!IsSamePolyType(e1, e2))
+      {
+#ifdef USINGZ
+        resultOp = AddLocalMinPoly(e1, e2, pt, false);
+        if (zCallback_) SetZ(e1, e2, resultOp->pt);
+#else
+        AddLocalMinPoly(e1, e2, pt, false);
+#endif
+      }
+      else if (old_e1_windcnt == 1 && old_e2_windcnt == 1)
+      {
+#ifdef USINGZ
+        resultOp = nullptr;
+#endif
+        switch (cliptype_)
+        {
+        case ClipType::Union:
+          if (e1Wc2 <= 0 && e2Wc2 <= 0)
+#ifdef USINGZ
+            resultOp = AddLocalMinPoly(e1, e2, pt, false);
+#else
+            AddLocalMinPoly(e1, e2, pt, false);
+#endif
+          break;
+        case ClipType::Difference:
+          if (((GetPolyType(e1) == PathType::Clip) && (e1Wc2 > 0) && (e2Wc2 > 0)) ||
+            ((GetPolyType(e1) == PathType::Subject) && (e1Wc2 <= 0) && (e2Wc2 <= 0)))
+          {
+#ifdef USINGZ
+            resultOp = AddLocalMinPoly(e1, e2, pt, false);
+#else
+            AddLocalMinPoly(e1, e2, pt, false);
+#endif
+          }
+          break;
+        case ClipType::Xor:
+#ifdef USINGZ
+          resultOp = AddLocalMinPoly(e1, e2, pt, false);
+#else
+          AddLocalMinPoly(e1, e2, pt, false);
+#endif
+          break;
+        default:
+          if (e1Wc2 > 0 && e2Wc2 > 0)
+#ifdef USINGZ
+            resultOp = AddLocalMinPoly(e1, e2, pt, false);
+#else
+            AddLocalMinPoly(e1, e2, pt, false);
+#endif
+          break;
+        }
+#ifdef USINGZ
+        if (resultOp && zCallback_) SetZ(e1, e2, resultOp->pt);
+#endif
+      }
+    }
+  }
+
+  inline void ClipperBase::DeleteFromAEL(Active& e)
+  {
+    Active* prev = e.prev_in_ael;
+    Active* next = e.next_in_ael;
+    if (!prev && !next && (&e != actives_)) return;  // already deleted
+    if (prev)
+      prev->next_in_ael = next;
+    else
+      actives_ = next;
+    if (next) next->prev_in_ael = prev;
+    delete& e;
+  }
+
+
+  inline void ClipperBase::AdjustCurrXAndCopyToSEL(const int64_t top_y)
+  {
+    Active* e = actives_;
+    sel_ = e;
+    while (e)
+    {
+      e->prev_in_sel = e->prev_in_ael;
+      e->next_in_sel = e->next_in_ael;
+      e->jump = e->next_in_sel;
+      // it is safe to ignore 'joined' edges here because
+      // if necessary they will be split in IntersectEdges()
+      e->curr_x = TopX(*e, top_y);
+      e = e->next_in_ael;
+    }
+  }
+
+  bool ClipperBase::ExecuteInternal(ClipType ct, FillRule fillrule, bool use_polytrees)
+  {
+    cliptype_ = ct;
+    fillrule_ = fillrule;
+    using_polytree_ = use_polytrees;
+    Reset();
+    int64_t y;
+    if (ct == ClipType::NoClip || !PopScanline(y)) return true;
+
+    while (succeeded_)
+    {
+      InsertLocalMinimaIntoAEL(y);
+      Active* e;
+      while (PopHorz(e)) DoHorizontal(*e);
+      if (horz_seg_list_.size() > 0)
+      {
+        ConvertHorzSegsToJoins();
+        horz_seg_list_.clear();
+      }
+      bot_y_ = y;  // bot_y_ == bottom of scanbeam
+      if (!PopScanline(y)) break;  // y new top of scanbeam
+      DoIntersections(y);
+      DoTopOfScanbeam(y);
+      while (PopHorz(e)) DoHorizontal(*e);
+    }
+    if (succeeded_) ProcessHorzJoins();
+    return succeeded_;
+  }
+
+  inline void FixOutRecPts(OutRec* outrec)
+  {
+    OutPt* op = outrec->pts;
+    do {
+      op->outrec = outrec;
+      op = op->next;
+    } while (op != outrec->pts);
+  }
+
+  inline bool SetHorzSegHeadingForward(HorzSegment& hs, OutPt* opP, OutPt* opN)
+  {
+    if (opP->pt.x == opN->pt.x) return false;
+    if (opP->pt.x < opN->pt.x)
+    {
+      hs.left_op = opP;
+      hs.right_op = opN;
+      hs.left_to_right = true;
+    }
+    else
+    {
+      hs.left_op = opN;
+      hs.right_op = opP;
+      hs.left_to_right = false;
+    }
+    return true;
+  }
+
+  inline bool UpdateHorzSegment(HorzSegment& hs)
+  {
+    OutPt* op = hs.left_op;
+    OutRec* outrec = GetRealOutRec(op->outrec);
+    bool outrecHasEdges = outrec->front_edge;
+    int64_t curr_y = op->pt.y;
+    OutPt* opP = op, * opN = op;
+    if (outrecHasEdges)
+    {
+      OutPt* opA = outrec->pts, * opZ = opA->next;
+      while (opP != opZ && opP->prev->pt.y == curr_y)
+        opP = opP->prev;
+      while (opN != opA && opN->next->pt.y == curr_y)
+        opN = opN->next;
+    }
+    else
+    {
+      while (opP->prev != opN && opP->prev->pt.y == curr_y)
+        opP = opP->prev;
+      while (opN->next != opP && opN->next->pt.y == curr_y)
+        opN = opN->next;
+    }
+    bool result =
+      SetHorzSegHeadingForward(hs, opP, opN) &&
+      !hs.left_op->horz;
+
+    if (result)
+      hs.left_op->horz = &hs;
+    else
+      hs.right_op = nullptr; // (for sorting)
+    return result;
+  }
+
+  void ClipperBase::ConvertHorzSegsToJoins()
+  {
+    auto j = std::count_if(horz_seg_list_.begin(),
+      horz_seg_list_.end(),
+      [](HorzSegment& hs) { return UpdateHorzSegment(hs); });
+    if (j < 2) return;
+
+    std::stable_sort(horz_seg_list_.begin(), horz_seg_list_.end(), HorzSegSorter());
+
+    HorzSegmentList::iterator hs1 = horz_seg_list_.begin(), hs2;
+    HorzSegmentList::iterator hs_end = hs1 +j;
+    HorzSegmentList::iterator hs_end1 = hs_end - 1;
+
+    for (; hs1 != hs_end1; ++hs1)
+    {
+      for (hs2 = hs1 + 1; hs2 != hs_end; ++hs2)
+      {
+        if ((hs2->left_op->pt.x >= hs1->right_op->pt.x) ||
+          (hs2->left_to_right == hs1->left_to_right) ||
+          (hs2->right_op->pt.x <= hs1->left_op->pt.x)) continue;
+        int64_t curr_y = hs1->left_op->pt.y;
+        if (hs1->left_to_right)
+        {
+          while (hs1->left_op->next->pt.y == curr_y &&
+            hs1->left_op->next->pt.x <= hs2->left_op->pt.x)
+            hs1->left_op = hs1->left_op->next;
+          while (hs2->left_op->prev->pt.y == curr_y &&
+            hs2->left_op->prev->pt.x <= hs1->left_op->pt.x)
+            hs2->left_op = hs2->left_op->prev;
+          HorzJoin join = HorzJoin(
+            DuplicateOp(hs1->left_op, true),
+            DuplicateOp(hs2->left_op, false));
+          horz_join_list_.emplace_back(join);
+        }
+        else
+        {
+          while (hs1->left_op->prev->pt.y == curr_y &&
+            hs1->left_op->prev->pt.x <= hs2->left_op->pt.x)
+            hs1->left_op = hs1->left_op->prev;
+          while (hs2->left_op->next->pt.y == curr_y &&
+            hs2->left_op->next->pt.x <= hs1->left_op->pt.x)
+            hs2->left_op = hs2->left_op->next;
+          HorzJoin join = HorzJoin(
+            DuplicateOp(hs2->left_op, true),
+            DuplicateOp(hs1->left_op, false));
+          horz_join_list_.emplace_back(join);
+        }
+      }
+    }
+  }
+
+  void MoveSplits(OutRec* fromOr, OutRec* toOr)
+  {
+    if (!toOr->splits) toOr->splits = new OutRecList();
+    OutRecList::iterator orIter = fromOr->splits->begin();
+    for (; orIter != fromOr->splits->end(); ++orIter)
+      if (toOr != *orIter) // #987
+        toOr->splits->emplace_back(*orIter);
+    fromOr->splits->clear();
+  }
+
+  void ClipperBase::ProcessHorzJoins()
+  {
+    for (const HorzJoin& j : horz_join_list_)
+    {
+      OutRec* or1 = GetRealOutRec(j.op1->outrec);
+      OutRec* or2 = GetRealOutRec(j.op2->outrec);
+
+      OutPt* op1b = j.op1->next;
+      OutPt* op2b = j.op2->prev;
+      j.op1->next = j.op2;
+      j.op2->prev = j.op1;
+      op1b->prev = op2b;
+      op2b->next = op1b;
+
+      if (or1 == or2) // 'join' is really a split
+      {
+        or2 = NewOutRec();
+        or2->pts = op1b;
+        FixOutRecPts(or2);
+
+        //if or1->pts has moved to or2 then update or1->pts!!
+        if (or1->pts->outrec == or2)
+        {
+          or1->pts = j.op1;
+          or1->pts->outrec = or1;
+        }
+
+        if (using_polytree_) //#498, #520, #584, D#576, #618
+        {          
+          if (Path2ContainsPath1(or1->pts, or2->pts))
+          {
+            //swap or1's & or2's pts
+            OutPt* tmp = or1->pts;
+            or1->pts = or2->pts;
+            or2->pts = tmp;
+            FixOutRecPts(or1);
+            FixOutRecPts(or2);
+            //or2 is now inside or1
+            or2->owner = or1;
+          }
+          else if (Path2ContainsPath1(or2->pts, or1->pts))
+          {
+            or2->owner = or1;
+          }
+          else
+            or2->owner = or1->owner;
+
+          if (!or1->splits) or1->splits = new OutRecList();
+          or1->splits->emplace_back(or2);
+        }
+        else
+          or2->owner = or1;
+      }
+      else // joining, not splitting
+      {
+        or2->pts = nullptr;
+        if (using_polytree_)
+        {
+          SetOwner(or2, or1);
+          if (or2->splits) 
+            MoveSplits(or2, or1); //#618
+        }
+        else
+          or2->owner = or1;
+      }
+    }
+  }
+
+  void ClipperBase::DoIntersections(const int64_t top_y)
+  {
+    if (BuildIntersectList(top_y))
+    {
+      ProcessIntersectList();
+      intersect_nodes_.clear();
+    }
+  }
+
+  void ClipperBase::AddNewIntersectNode(Active& e1, Active& e2, int64_t top_y)
+  {
+    Point64 ip;
+    if (!GetSegmentIntersectPt(e1.bot, e1.top, e2.bot, e2.top, ip))
+      ip = Point64(e1.curr_x, top_y); //parallel edges
+
+    //rounding errors can occasionally place the calculated intersection
+    //point either below or above the scanbeam, so check and correct ...
+    if (ip.y > bot_y_ || ip.y < top_y)
+    {
+      double abs_dx1 = std::fabs(e1.dx);
+      double abs_dx2 = std::fabs(e2.dx);
+      if (abs_dx1 > 100 && abs_dx2 > 100)
+      {
+        if (abs_dx1 > abs_dx2)
+          ip = GetClosestPointOnSegment(ip, e1.bot, e1.top);
+        else
+          ip = GetClosestPointOnSegment(ip, e2.bot, e2.top);
+      }
+      else if (abs_dx1 > 100)
+        ip = GetClosestPointOnSegment(ip, e1.bot, e1.top);
+      else if (abs_dx2 > 100)
+        ip = GetClosestPointOnSegment(ip, e2.bot, e2.top);
+      else
+      {
+        if (ip.y < top_y) ip.y = top_y;
+        else ip.y = bot_y_;
+        if (abs_dx1 < abs_dx2) ip.x = TopX(e1, ip.y);
+        else ip.x = TopX(e2, ip.y);
+      }
+    }
+    intersect_nodes_.emplace_back(&e1, &e2, ip);
+  }
+
+  bool ClipperBase::BuildIntersectList(const int64_t top_y)
+  {
+    if (!actives_ || !actives_->next_in_ael) return false;
+
+    //Calculate edge positions at the top of the current scanbeam, and from this
+    //we will determine the intersections required to reach these new positions.
+    AdjustCurrXAndCopyToSEL(top_y);
+    //Find all edge intersections in the current scanbeam using a stable merge
+    //sort that ensures only adjacent edges are intersecting. Intersect info is
+    //stored in FIntersectList ready to be processed in ProcessIntersectList.
+    //Re merge sorts see https://stackoverflow.com/a/46319131/359538
+
+    Active* left = sel_, * right, * l_end, * r_end, * curr_base, * tmp;
+
+    while (left && left->jump)
+    {
+      Active* prev_base = nullptr;
+      while (left && left->jump)
+      {
+        curr_base = left;
+        right = left->jump;
+        l_end = right;
+        r_end = right->jump;
+        left->jump = r_end;
+        while (left != l_end && right != r_end)
+        {
+          if (right->curr_x < left->curr_x)
+          {
+            tmp = right->prev_in_sel;
+            for (; ; )
+            {
+              AddNewIntersectNode(*tmp, *right, top_y);
+              if (tmp == left) break;
+              tmp = tmp->prev_in_sel;
+            }
+
+            tmp = right;
+            right = ExtractFromSEL(tmp);
+            l_end = right;
+            Insert1Before2InSEL(tmp, left);
+            if (left == curr_base)
+            {
+              curr_base = tmp;
+              curr_base->jump = r_end;
+              if (!prev_base) sel_ = curr_base;
+              else prev_base->jump = curr_base;
+            }
+          }
+          else left = left->next_in_sel;
+        }
+        prev_base = curr_base;
+        left = r_end;
+      }
+      left = sel_;
+    }
+    return intersect_nodes_.size() > 0;
+  }
+
+  void ClipperBase::ProcessIntersectList()
+  {
+    //We now have a list of intersections required so that edges will be
+    //correctly positioned at the top of the scanbeam. However, it's important
+    //that edge intersections are processed from the bottom up, but it's also
+    //crucial that intersections only occur between adjacent edges.
+
+    //First we do a quicksort so intersections proceed in a bottom up order ...
+    std::sort(intersect_nodes_.begin(), intersect_nodes_.end(), IntersectListSort);
+    //Now as we process these intersections, we must sometimes adjust the order
+    //to ensure that intersecting edges are always adjacent ...
+
+    IntersectNodeList::iterator node_iter, node_iter2;
+    for (node_iter = intersect_nodes_.begin();
+      node_iter != intersect_nodes_.end();  ++node_iter)
+    {
+      if (!EdgesAdjacentInAEL(*node_iter))
+      {
+        node_iter2 = node_iter + 1;
+        while (!EdgesAdjacentInAEL(*node_iter2)) ++node_iter2;
+        std::swap(*node_iter, *node_iter2);
+      }
+
+      IntersectNode& node = *node_iter;
+      IntersectEdges(*node.edge1, *node.edge2, node.pt);
+      SwapPositionsInAEL(*node.edge1, *node.edge2);
+
+      node.edge1->curr_x = node.pt.x;
+      node.edge2->curr_x = node.pt.x;
+      CheckJoinLeft(*node.edge2, node.pt, true);
+      CheckJoinRight(*node.edge1, node.pt, true);
+    }
+  }
+
+  void ClipperBase::SwapPositionsInAEL(Active& e1, Active& e2)
+  {
+    //preconditon: e1 must be immediately to the left of e2
+    Active* next = e2.next_in_ael;
+    if (next) next->prev_in_ael = &e1;
+    Active* prev = e1.prev_in_ael;
+    if (prev) prev->next_in_ael = &e2;
+    e2.prev_in_ael = prev;
+    e2.next_in_ael = &e1;
+    e1.prev_in_ael = &e2;
+    e1.next_in_ael = next;
+    if (!e2.prev_in_ael) actives_ = &e2;
+  }
+
+  inline OutPt* GetLastOp(const Active& hot_edge)
+  {
+    OutRec* outrec = hot_edge.outrec;
+    OutPt* result = outrec->pts;
+    if (&hot_edge != outrec->front_edge)
+      result = result->next;
+    return result;
+  }
+
+  void ClipperBase::AddTrialHorzJoin(OutPt* op)
+  {
+    if (op->outrec->is_open) return;
+    horz_seg_list_.emplace_back(op);
+  }
+
+  bool ClipperBase::ResetHorzDirection(const Active& horz,
+    const Vertex* max_vertex, int64_t& horz_left, int64_t& horz_right)
+  {
+    if (horz.bot.x == horz.top.x)
+    {
+      //the horizontal edge is going nowhere ...
+      horz_left = horz.curr_x;
+      horz_right = horz.curr_x;
+      Active* e = horz.next_in_ael;
+      while (e && e->vertex_top != max_vertex) e = e->next_in_ael;
+      return e != nullptr;
+    }
+    else if (horz.curr_x < horz.top.x)
+    {
+      horz_left = horz.curr_x;
+      horz_right = horz.top.x;
+      return true;
+    }
+    else
+    {
+      horz_left = horz.top.x;
+      horz_right = horz.curr_x;
+      return false;  // right to left
+    }
+  }
+
+  void ClipperBase::DoHorizontal(Active& horz)
+    /*******************************************************************************
+        * Notes: Horizontal edges (HEs) at scanline intersections (ie at the top or    *
+        * bottom of a scanbeam) are processed as if layered.The order in which HEs     *
+        * are processed doesn't matter. HEs intersect with the bottom vertices of      *
+        * other HEs[#] and with non-horizontal edges [*]. Once these intersections     *
+        * are completed, intermediate HEs are 'promoted' to the next edge in their     *
+        * bounds, and they in turn may be intersected[%] by other HEs.                 *
+        *                                                                              *
+        * eg: 3 horizontals at a scanline:    /   |                     /           /  *
+        *              |                     /    |     (HE3)o ========%========== o   *
+        *              o ======= o(HE2)     /     |         /         /                *
+        *          o ============#=========*======*========#=========o (HE1)           *
+        *         /              |        /       |       /                            *
+        *******************************************************************************/
+  {
+    Point64 pt;
+    bool horzIsOpen = IsOpen(horz);
+    int64_t y = horz.bot.y;
+    Vertex* vertex_max;
+    if (horzIsOpen)
+      vertex_max = GetCurrYMaximaVertex_Open(horz);
+    else
+      vertex_max = GetCurrYMaximaVertex(horz);
+
+    //// remove 180 deg.spikes and also simplify
+    //// consecutive horizontals when PreserveCollinear = true
+    //if (!horzIsOpen && vertex_max != horz.vertex_top)
+    //  TrimHorz(horz, PreserveCollinear);
+
+    int64_t horz_left, horz_right;
+    bool is_left_to_right =
+      ResetHorzDirection(horz, vertex_max, horz_left, horz_right);
+
+    if (IsHotEdge(horz))
+    {
+#ifdef USINGZ
+      OutPt* op = AddOutPt(horz, Point64(horz.curr_x, y, horz.bot.z));
+#else
+      OutPt* op = AddOutPt(horz, Point64(horz.curr_x, y));
+#endif
+      AddTrialHorzJoin(op);
+    }
+
+    while (true) // loop through consec. horizontal edges
+    {
+      Active* e;
+      if (is_left_to_right) e = horz.next_in_ael;
+      else e = horz.prev_in_ael;
+
+      while (e)
+      {
+        if (e->vertex_top == vertex_max)
+        {
+          if (IsHotEdge(horz) && IsJoined(*e))
+            Split(*e, e->top);
+
+          //if (IsHotEdge(horz) != IsHotEdge(*e))
+          //    DoError(undefined_error_i);
+
+          if (IsHotEdge(horz))
+          {
+            while (horz.vertex_top != vertex_max)
+            {
+              AddOutPt(horz, horz.top);
+              UpdateEdgeIntoAEL(&horz);
+            }
+            if (is_left_to_right)
+              AddLocalMaxPoly(horz, *e, horz.top);
+            else
+              AddLocalMaxPoly(*e, horz, horz.top);
+          }
+          DeleteFromAEL(*e);
+          DeleteFromAEL(horz);
+          return;
+        }
+
+        //if horzEdge is a maxima, keep going until we reach
+        //its maxima pair, otherwise check for break conditions
+        if (vertex_max != horz.vertex_top || IsOpenEnd(horz))
+        {
+          //otherwise stop when 'ae' is beyond the end of the horizontal line
+          if ((is_left_to_right && e->curr_x > horz_right) ||
+            (!is_left_to_right && e->curr_x < horz_left)) break;
+
+          if (e->curr_x == horz.top.x && !IsHorizontal(*e))
+          {
+            pt = NextVertex(horz)->pt;
+            if (is_left_to_right)
+            {
+              //with open paths we'll only break once past horz's end
+              if (IsOpen(*e) && !IsSamePolyType(*e, horz) && !IsHotEdge(*e))
+              {
+                if (TopX(*e, pt.y) > pt.x) break;
+              }
+              //otherwise we'll only break when horz's outslope is greater than e's
+              else if (TopX(*e, pt.y) >= pt.x) break;
+            }
+            else
+            {
+              if (IsOpen(*e) && !IsSamePolyType(*e, horz) && !IsHotEdge(*e))
+              {
+                if (TopX(*e, pt.y) < pt.x) break;
+              }
+              else if (TopX(*e, pt.y) <= pt.x) break;
+            }
+          }
+        }
+
+        pt = Point64(e->curr_x, horz.bot.y);
+        if (is_left_to_right)
+        {
+          IntersectEdges(horz, *e, pt);
+          SwapPositionsInAEL(horz, *e);
+          CheckJoinLeft(*e, pt);
+          horz.curr_x = e->curr_x;
+          e = horz.next_in_ael;
+        }
+        else
+        {
+          IntersectEdges(*e, horz, pt);
+          SwapPositionsInAEL(*e, horz);
+          CheckJoinRight(*e, pt);
+          horz.curr_x = e->curr_x;
+          e = horz.prev_in_ael;
+        }
+
+        if (horz.outrec)
+        {
+          //nb: The outrec containing the op returned by IntersectEdges
+          //above may no longer be associated with horzEdge.
+          AddTrialHorzJoin(GetLastOp(horz));
+        }
+      }
+
+      //check if we've finished with (consecutive) horizontals ...
+      if (horzIsOpen && IsOpenEnd(horz)) // ie open at top
+      {
+        if (IsHotEdge(horz))
+        {
+          AddOutPt(horz, horz.top);
+          if (IsFront(horz))
+            horz.outrec->front_edge = nullptr;
+          else
+            horz.outrec->back_edge = nullptr;
+          horz.outrec = nullptr;
+        }
+        DeleteFromAEL(horz);
+        return;
+      }
+      else if (NextVertex(horz)->pt.y != horz.top.y)
+        break;
+
+      //still more horizontals in bound to process ...
+      if (IsHotEdge(horz))
+        AddOutPt(horz, horz.top);
+      UpdateEdgeIntoAEL(&horz);
+
+      is_left_to_right =
+        ResetHorzDirection(horz, vertex_max, horz_left, horz_right);
+    }
+
+    if (IsHotEdge(horz))
+    {
+      OutPt* op = AddOutPt(horz, horz.top);
+      AddTrialHorzJoin(op);
+    }
+
+    UpdateEdgeIntoAEL(&horz); // end of an intermediate horiz.
+  }
+
+  void ClipperBase::DoTopOfScanbeam(const int64_t y)
+  {
+    sel_ = nullptr;  // sel_ is reused to flag horizontals (see PushHorz below)
+    Active* e = actives_;
+    while (e)
+    {
+      //nb: 'e' will never be horizontal here
+      if (e->top.y == y)
+      {
+        e->curr_x = e->top.x;
+        if (IsMaxima(*e))
+        {
+          e = DoMaxima(*e);  // TOP OF BOUND (MAXIMA)
+          continue;
+        }
+        else
+        {
+          //INTERMEDIATE VERTEX ...
+          if (IsHotEdge(*e)) AddOutPt(*e, e->top);
+          UpdateEdgeIntoAEL(e);
+          if (IsHorizontal(*e))
+            PushHorz(*e);  // horizontals are processed later
+        }
+      }
+      else // i.e. not the top of the edge
+        e->curr_x = TopX(*e, y);
+
+      e = e->next_in_ael;
+    }
+  }
+
+
+  Active* ClipperBase::DoMaxima(Active& e)
+  {
+    Active* next_e, * prev_e, * max_pair;
+    prev_e = e.prev_in_ael;
+    next_e = e.next_in_ael;
+    if (IsOpenEnd(e))
+    {
+      if (IsHotEdge(e)) AddOutPt(e, e.top);
+      if (!IsHorizontal(e))
+      {
+        if (IsHotEdge(e))
+        {
+          if (IsFront(e))
+            e.outrec->front_edge = nullptr;
+          else
+            e.outrec->back_edge = nullptr;
+          e.outrec = nullptr;
+        }
+        DeleteFromAEL(e);
+      }
+      return next_e;
+    }
+
+    max_pair = GetMaximaPair(e);
+    if (!max_pair) return next_e;  // eMaxPair is horizontal
+
+    if (IsJoined(e)) Split(e, e.top);
+    if (IsJoined(*max_pair)) Split(*max_pair, max_pair->top);
+
+    //only non-horizontal maxima here.
+    //process any edges between maxima pair ...
+    while (next_e != max_pair)
+    {
+      IntersectEdges(e, *next_e, e.top);
+      SwapPositionsInAEL(e, *next_e);
+      next_e = e.next_in_ael;
+    }
+
+    if (IsOpen(e))
+    {
+      if (IsHotEdge(e))
+        AddLocalMaxPoly(e, *max_pair, e.top);
+      DeleteFromAEL(*max_pair);
+      DeleteFromAEL(e);
+      return (prev_e ? prev_e->next_in_ael : actives_);
+    }
+
+    // e.next_in_ael== max_pair ...
+    if (IsHotEdge(e))
+      AddLocalMaxPoly(e, *max_pair, e.top);
+
+    DeleteFromAEL(e);
+    DeleteFromAEL(*max_pair);
+    return (prev_e ? prev_e->next_in_ael : actives_);
+  }
+
+  void ClipperBase::Split(Active& e, const Point64& pt)
+  {
+    if (e.join_with == JoinWith::Right)
+    {
+      e.join_with = JoinWith::NoJoin;
+      e.next_in_ael->join_with = JoinWith::NoJoin;
+      AddLocalMinPoly(e, *e.next_in_ael, pt, true);
+    }
+    else
+    {
+      e.join_with = JoinWith::NoJoin;
+      e.prev_in_ael->join_with = JoinWith::NoJoin;
+      AddLocalMinPoly(*e.prev_in_ael, e, pt, true);
+    }
+  }
+
+  void ClipperBase::CheckJoinLeft(Active& e,
+    const Point64& pt, bool check_curr_x)
+  {
+    Active* prev = e.prev_in_ael;
+    if (!prev ||
+      !IsHotEdge(e) || !IsHotEdge(*prev) ||
+      IsHorizontal(e) || IsHorizontal(*prev) ||
+      IsOpen(e) || IsOpen(*prev) ) return;
+    if ((pt.y < e.top.y + 2 || pt.y < prev->top.y + 2) &&
+      ((e.bot.y > pt.y) || (prev->bot.y > pt.y))) return; // avoid trivial joins
+
+    if (check_curr_x)
+    {
+      if (PerpendicDistFromLineSqrd(pt, prev->bot, prev->top) > 0.25) return;
+    }
+    else if (e.curr_x != prev->curr_x) return;
+    if (!IsCollinear(e.top, pt, prev->top)) return;
+
+    if (e.outrec->idx == prev->outrec->idx)
+      AddLocalMaxPoly(*prev, e, pt);
+    else if (e.outrec->idx < prev->outrec->idx)
+      JoinOutrecPaths(e, *prev);
+    else
+      JoinOutrecPaths(*prev, e);
+    prev->join_with = JoinWith::Right;
+    e.join_with = JoinWith::Left;
+  }
+
+  void ClipperBase::CheckJoinRight(Active& e,
+    const Point64& pt, bool check_curr_x)
+  {
+    Active* next = e.next_in_ael;
+    if (!next ||
+      !IsHotEdge(e) || !IsHotEdge(*next) ||
+      IsHorizontal(e) || IsHorizontal(*next) ||
+      IsOpen(e) || IsOpen(*next)) return;
+    if ((pt.y < e.top.y +2 || pt.y < next->top.y +2) &&
+      ((e.bot.y > pt.y) || (next->bot.y > pt.y))) return; // avoid trivial joins
+
+    if (check_curr_x)
+    {
+      if (PerpendicDistFromLineSqrd(pt, next->bot, next->top) > 0.35) return;
+    }
+    else if (e.curr_x != next->curr_x) return;
+    if (!IsCollinear(e.top, pt, next->top)) return;
+
+    if (e.outrec->idx == next->outrec->idx)
+      AddLocalMaxPoly(e, *next, pt);
+    else if (e.outrec->idx < next->outrec->idx)
+      JoinOutrecPaths(e, *next);
+    else
+      JoinOutrecPaths(*next, e);
+
+    e.join_with = JoinWith::Right;
+    next->join_with = JoinWith::Left;
+  }
+
+  inline bool GetHorzExtendedHorzSeg(OutPt*& op, OutPt*& op2)
+  {
+    OutRec* outrec = GetRealOutRec(op->outrec);
+    op2 = op;
+    if (outrec->front_edge)
+    {
+      while (op->prev != outrec->pts &&
+        op->prev->pt.y == op->pt.y) op = op->prev;
+      while (op2 != outrec->pts &&
+        op2->next->pt.y == op2->pt.y) op2 = op2->next;
+      return op2 != op;
+    }
+    else
+    {
+      while (op->prev != op2 && op->prev->pt.y == op->pt.y)
+        op = op->prev;
+      while (op2->next != op && op2->next->pt.y == op2->pt.y)
+        op2 = op2->next;
+      return op2 != op && op2->next != op;
+    }
+  }
+
+  bool BuildPath64(OutPt* op, bool reverse, bool isOpen, Path64& path)
+  {
+    if (!op || op->next == op || (!isOpen && op->next == op->prev))
+      return false;
+
+    path.resize(0);
+    Point64 lastPt;
+    OutPt* op2;
+    if (reverse)
+    {
+      lastPt = op->pt;
+      op2 = op->prev;
+    }
+    else
+    {
+      op = op->next;
+      lastPt = op->pt;
+      op2 = op->next;
+    }
+    path.emplace_back(lastPt);
+
+    while (op2 != op)
+    {
+      if (op2->pt != lastPt)
+      {
+        lastPt = op2->pt;
+        path.emplace_back(lastPt);
+      }
+      if (reverse)
+        op2 = op2->prev;
+      else
+        op2 = op2->next;
+    }
+
+    if (!isOpen && path.size() == 3 && IsVerySmallTriangle(*op2)) return false;
+    else return true;
+  }
+
+  bool ClipperBase::CheckBounds(OutRec* outrec)
+  {
+    if (!outrec->pts) return false;
+    if (!outrec->bounds.IsEmpty()) return true;
+    CleanCollinear(outrec);
+    if (!outrec->pts ||
+      !BuildPath64(outrec->pts, reverse_solution_, false, outrec->path)){
+        return false;}
+    outrec->bounds = GetBounds(outrec->path);
+    return true;
+  }
+
+  bool ClipperBase::CheckSplitOwner(OutRec* outrec, OutRecList* splits)
+  {
+    for (auto split : *splits)
+    {
+      if (!split->pts && split->splits &&
+        CheckSplitOwner(outrec, split->splits)) return true; //#942
+      split = GetRealOutRec(split);
+      if (!split || split == outrec || split->recursive_split == outrec) continue;
+      split->recursive_split = outrec; // prevent infinite loops
+
+      if (split->splits && CheckSplitOwner(outrec, split->splits))
+        return true;    
+
+      if (!CheckBounds(split) || !split->bounds.Contains(outrec->bounds) ||
+        !Path2ContainsPath1(outrec->pts, split->pts)) continue;
+     
+      if (!IsValidOwner(outrec, split)) // split is owned by outrec! (#957)
+          split->owner = outrec->owner;
+
+      outrec->owner = split;
+      return true;
+      
+    }
+    return false;
+  }
+
+  void ClipperBase::RecursiveCheckOwners(OutRec* outrec, PolyPath* polypath)
+  {
+    // pre-condition: outrec will have valid bounds
+    // post-condition: if a valid path, outrec will have a polypath
+
+    if (outrec->polypath || outrec->bounds.IsEmpty()) return;
+    while (outrec->owner)
+    {
+      if (outrec->owner->splits && CheckSplitOwner(outrec, outrec->owner->splits)) break;
+      if (outrec->owner->pts && CheckBounds(outrec->owner) &&
+        outrec->owner->bounds.Contains(outrec->bounds) &&
+        Path2ContainsPath1(outrec->pts, outrec->owner->pts)) break;
+      outrec->owner = outrec->owner->owner;
+    }
+
+    if (outrec->owner)
+    {
+      if (!outrec->owner->polypath)
+        RecursiveCheckOwners(outrec->owner, polypath);
+      outrec->polypath = outrec->owner->polypath->AddChild(outrec->path);
+    }
+    else
+      outrec->polypath = polypath->AddChild(outrec->path);
+  }
+
+  void Clipper64::BuildPaths64(Paths64& solutionClosed, Paths64* solutionOpen)
+  {
+    solutionClosed.resize(0);
+    solutionClosed.reserve(outrec_list_.size());
+    if (solutionOpen)
+    {
+      solutionOpen->resize(0);
+      solutionOpen->reserve(outrec_list_.size());
+    }
+
+    // nb: outrec_list_.size() may change in the following
+    // while loop because polygons may be split during
+    // calls to CleanCollinear which calls FixSelfIntersects
+    for (size_t i = 0; i < outrec_list_.size(); ++i)
+    {
+      OutRec* outrec = outrec_list_[i];
+      if (outrec->pts == nullptr) continue;
+
+      Path64 path;
+      if (solutionOpen && outrec->is_open)
+      {
+        if (BuildPath64(outrec->pts, reverse_solution_, true, path))
+          solutionOpen->emplace_back(std::move(path));
+      }
+      else
+      {
+        // nb: CleanCollinear can add to outrec_list_
+        CleanCollinear(outrec);
+        //closed paths should always return a Positive orientation
+        if (BuildPath64(outrec->pts, reverse_solution_, false, path))
+          solutionClosed.emplace_back(std::move(path));
+      }
+    }
+  }
+
+  void Clipper64::BuildTree64(PolyPath64& polytree, Paths64& open_paths)
+  {
+    polytree.Clear();
+    open_paths.resize(0);
+    if (has_open_paths_)
+      open_paths.reserve(outrec_list_.size());
+
+    // outrec_list_.size() is not static here because
+    // CheckBounds below can indirectly add additional
+    // OutRec (via FixOutRecPts & CleanCollinear)
+    for (size_t i = 0; i < outrec_list_.size(); ++i)
+    {
+      OutRec* outrec = outrec_list_[i];
+      if (!outrec || !outrec->pts) continue;
+
+      if (outrec->is_open)
+      {
+        Path64 path;
+        if (BuildPath64(outrec->pts, reverse_solution_, true, path))
+          open_paths.emplace_back(std::move(path));
+        continue;
+      }
+
+      if (CheckBounds(outrec))
+        RecursiveCheckOwners(outrec, &polytree);
+    }
+  }
+
+  bool BuildPathD(OutPt* op, bool reverse, bool isOpen, PathD& path, double inv_scale)
+  {
+    if (!op || op->next == op || (!isOpen && op->next == op->prev))
+      return false;
+
+    path.resize(0);
+    Point64 lastPt;
+    OutPt* op2;
+    if (reverse)
+    {
+      lastPt = op->pt;
+      op2 = op->prev;
+    }
+    else
+    {
+      op = op->next;
+      lastPt = op->pt;
+      op2 = op->next;
+    }
+#ifdef USINGZ
+    path.emplace_back(lastPt.x * inv_scale, lastPt.y * inv_scale, lastPt.z);
+#else
+    path.emplace_back(lastPt.x * inv_scale, lastPt.y * inv_scale);
+#endif
+
+    while (op2 != op)
+    {
+      if (op2->pt != lastPt)
+      {
+        lastPt = op2->pt;
+#ifdef USINGZ
+        path.emplace_back(lastPt.x * inv_scale, lastPt.y * inv_scale, lastPt.z);
+#else
+        path.emplace_back(lastPt.x * inv_scale, lastPt.y * inv_scale);
+#endif
+
+      }
+      if (reverse)
+        op2 = op2->prev;
+      else
+        op2 = op2->next;
+    }
+    if (path.size() == 3 && IsVerySmallTriangle(*op2)) return false;
+    return true;
+  }
+
+  void ClipperD::BuildPathsD(PathsD& solutionClosed, PathsD* solutionOpen)
+  {
+    solutionClosed.resize(0);
+    solutionClosed.reserve(outrec_list_.size());
+    if (solutionOpen)
+    {
+      solutionOpen->resize(0);
+      solutionOpen->reserve(outrec_list_.size());
+    }
+
+    // outrec_list_.size() is not static here because
+    // CleanCollinear below can indirectly add additional
+    // OutRec (via FixOutRecPts)
+    for (std::size_t i = 0; i < outrec_list_.size(); ++i)
+    {
+      OutRec* outrec = outrec_list_[i];
+      if (outrec->pts == nullptr) continue;
+
+      PathD path;
+      if (solutionOpen && outrec->is_open)
+      {
+        if (BuildPathD(outrec->pts, reverse_solution_, true, path, invScale_))
+          solutionOpen->emplace_back(std::move(path));
+      }
+      else
+      {
+        CleanCollinear(outrec);
+        //closed paths should always return a Positive orientation
+        if (BuildPathD(outrec->pts, reverse_solution_, false, path, invScale_))
+          solutionClosed.emplace_back(std::move(path));
+      }
+    }
+  }
+
+  void ClipperD::BuildTreeD(PolyPathD& polytree, PathsD& open_paths)
+  {
+    polytree.Clear();
+    open_paths.resize(0);
+    if (has_open_paths_)
+      open_paths.reserve(outrec_list_.size());
+
+    // outrec_list_.size() is not static here because
+    // BuildPathD below can indirectly add additional OutRec //#607
+    for (size_t i = 0; i < outrec_list_.size(); ++i)
+    {
+      OutRec* outrec = outrec_list_[i];
+      if (!outrec || !outrec->pts) continue;
+      if (outrec->is_open)
+      {
+        PathD path;
+        if (BuildPathD(outrec->pts, reverse_solution_, true, path, invScale_))
+          open_paths.emplace_back(std::move(path));
+        continue;
+      }
+
+      if (CheckBounds(outrec))
+        RecursiveCheckOwners(outrec, &polytree);
+    }
+  }
+
+}  // namespace clipper2lib

--- a/FrameDirector/third_party/clipper2/src/clipper.offset.cpp
+++ b/FrameDirector/third_party/clipper2/src/clipper.offset.cpp
@@ -1,0 +1,661 @@
+/*******************************************************************************
+* Author    :  Angus Johnson                                                   *
+* Date      :  4 May 2025                                                      *
+* Website   :  https://www.angusj.com                                          *
+* Copyright :  Angus Johnson 2010-2025                                         *
+* Purpose   :  Path Offset (Inflate/Shrink)                                    *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
+*******************************************************************************/
+
+#include "clipper2/clipper.h"
+#include "clipper2/clipper.offset.h"
+
+namespace Clipper2Lib {
+
+const double floating_point_tolerance = 1e-12;
+
+// Clipper2 approximates arcs by using series of relatively short straight
+//line segments. And logically, shorter line segments will produce better arc
+// approximations. But very short segments can degrade performance, usually
+// with little or no discernable improvement in curve quality. Very short
+// segments can even detract from curve quality, due to the effects of integer
+// rounding. Since there isn't an optimal number of line segments for any given
+// arc radius (that perfectly balances curve approximation with performance),
+// arc tolerance is user defined. Nevertheless, when the user doesn't define
+// an arc tolerance (ie leaves alone the 0 default value), the calculated
+// default arc tolerance (offset_radius / 500) generally produces good (smooth)
+// arc approximations without producing excessively small segment lengths.
+// See also: https://www.angusj.com/clipper2/Docs/Trigonometry.htm
+const double arc_const = 0.002; // <-- 1/500
+
+
+//------------------------------------------------------------------------------
+// Miscellaneous methods
+//------------------------------------------------------------------------------
+
+void GetLowestClosedPathInfo(const Paths64& paths, std::optional<size_t>& idx, bool& is_neg_area)
+{
+	idx.reset();
+	Point64 botPt = Point64(INT64_MAX, INT64_MIN);
+	for (size_t i = 0; i < paths.size(); ++i)
+	{
+		double a = MAX_DBL;
+		for (const Point64& pt : paths[i])
+		{
+			if ((pt.y < botPt.y) ||
+				((pt.y == botPt.y) && (pt.x >= botPt.x))) continue;
+			if (a == MAX_DBL) 
+			{
+				a = Area(paths[i]);
+				if (a == 0) break; // invalid closed path, so break from inner loop
+				is_neg_area = a < 0;
+			}
+      idx = i;
+			botPt.x = pt.x;
+			botPt.y = pt.y;
+		}
+	}
+}
+
+inline double Hypot(double x, double y)
+{
+	// given that this is an internal function, and given the x and y parameters
+	// will always be coordinate values (or the difference between coordinate values),
+	// x and y should always be within INT64_MIN to INT64_MAX. Consequently, 
+	// there should be no risk that the following computation will overflow
+	// see https://stackoverflow.com/a/32436148/359538
+	return std::sqrt(x * x + y * y);
+}
+
+static PointD GetUnitNormal(const Point64& pt1, const Point64& pt2)
+{
+	if (pt1 == pt2) return PointD(0.0, 0.0);
+	double dx = static_cast<double>(pt2.x - pt1.x);
+	double dy = static_cast<double>(pt2.y - pt1.y);
+	double inverse_hypot = 1.0 / Hypot(dx, dy);
+	dx *= inverse_hypot;
+	dy *= inverse_hypot;
+	return PointD(dy, -dx);
+}
+
+inline bool AlmostZero(double value, double epsilon = 0.001)
+{
+	return std::fabs(value) < epsilon;
+}
+
+inline PointD NormalizeVector(const PointD& vec)
+{
+	double h = Hypot(vec.x, vec.y);
+	if (AlmostZero(h)) return PointD(0,0);
+	double inverseHypot = 1 / h;
+	return PointD(vec.x * inverseHypot, vec.y * inverseHypot);
+}
+
+inline PointD GetAvgUnitVector(const PointD& vec1, const PointD& vec2)
+{
+	return NormalizeVector(PointD(vec1.x + vec2.x, vec1.y + vec2.y));
+}
+
+inline bool IsClosedPath(EndType et)
+{
+	return et == EndType::Polygon || et == EndType::Joined;
+}
+
+static inline Point64 GetPerpendic(const Point64& pt, const PointD& norm, double delta)
+{
+#ifdef USINGZ
+	return Point64(pt.x + norm.x * delta, pt.y + norm.y * delta, pt.z);
+#else
+	return Point64(pt.x + norm.x * delta, pt.y + norm.y * delta);
+#endif
+}
+
+inline PointD GetPerpendicD(const Point64& pt, const PointD& norm, double delta)
+{
+#ifdef USINGZ
+	return PointD(pt.x + norm.x * delta, pt.y + norm.y * delta, pt.z);
+#else
+	return PointD(pt.x + norm.x * delta, pt.y + norm.y * delta);
+#endif
+}
+
+inline void NegatePath(PathD& path)
+{
+	for (PointD& pt : path)
+	{
+		pt.x = -pt.x;
+		pt.y = -pt.y;
+#ifdef USINGZ
+		pt.z = pt.z;
+#endif
+	}
+}
+
+
+//------------------------------------------------------------------------------
+// ClipperOffset::Group methods
+//------------------------------------------------------------------------------
+
+ClipperOffset::Group::Group(const Paths64& _paths, JoinType _join_type, EndType _end_type):
+	paths_in(_paths), join_type(_join_type), end_type(_end_type)
+{
+	bool is_joined =
+		(end_type == EndType::Polygon) ||
+		(end_type == EndType::Joined);
+	for (Path64& p: paths_in)
+	  StripDuplicates(p, is_joined);
+
+	if (end_type == EndType::Polygon)
+	{
+		bool is_neg_area;
+		GetLowestClosedPathInfo(paths_in, lowest_path_idx, is_neg_area);
+		// the lowermost path must be an outer path, so if its orientation is negative,
+		// then flag the whole group is 'reversed' (will negate delta etc.)
+		// as this is much more efficient than reversing every path.
+    is_reversed = lowest_path_idx.has_value() && is_neg_area;
+	}
+	else
+	{
+    lowest_path_idx.reset();
+		is_reversed = false;
+	}
+}
+
+//------------------------------------------------------------------------------
+// ClipperOffset methods
+//------------------------------------------------------------------------------
+
+void ClipperOffset::AddPath(const Path64& path, JoinType jt_, EndType et_)
+{
+    groups_.emplace_back(Paths64(1, path), jt_, et_);
+}
+
+void ClipperOffset::AddPaths(const Paths64 &paths, JoinType jt_, EndType et_)
+{
+	if (paths.size() == 0) return;
+    groups_.emplace_back(paths, jt_, et_);
+}
+
+void ClipperOffset::BuildNormals(const Path64& path)
+{
+	norms.clear();
+	norms.reserve(path.size());
+	if (path.size() == 0) return;
+	Path64::const_iterator path_iter, path_stop_iter = --path.cend();
+	for (path_iter = path.cbegin(); path_iter != path_stop_iter; ++path_iter)
+        norms.emplace_back(GetUnitNormal(*path_iter,*(path_iter +1)));
+    norms.emplace_back(GetUnitNormal(*path_stop_iter, *(path.cbegin())));
+}
+
+void ClipperOffset::DoBevel(const Path64& path, size_t j, size_t k)
+{
+	PointD pt1, pt2;
+	if (j == k)
+	{
+		double abs_delta = std::abs(group_delta_);
+#ifdef USINGZ
+		pt1 = PointD(path[j].x - abs_delta * norms[j].x, path[j].y - abs_delta * norms[j].y, path[j].z);
+		pt2 = PointD(path[j].x + abs_delta * norms[j].x, path[j].y + abs_delta * norms[j].y, path[j].z);
+#else
+		pt1 = PointD(path[j].x - abs_delta * norms[j].x, path[j].y - abs_delta * norms[j].y);
+		pt2 = PointD(path[j].x + abs_delta * norms[j].x, path[j].y + abs_delta * norms[j].y);
+#endif
+	}
+	else
+	{
+#ifdef USINGZ
+		pt1 = PointD(path[j].x + group_delta_ * norms[k].x, path[j].y + group_delta_ * norms[k].y, path[j].z);
+		pt2 = PointD(path[j].x + group_delta_ * norms[j].x, path[j].y + group_delta_ * norms[j].y, path[j].z);
+#else
+		pt1 = PointD(path[j].x + group_delta_ * norms[k].x, path[j].y + group_delta_ * norms[k].y);
+		pt2 = PointD(path[j].x + group_delta_ * norms[j].x, path[j].y + group_delta_ * norms[j].y);
+#endif
+	}
+    path_out.emplace_back(pt1);
+    path_out.emplace_back(pt2);
+}
+
+void ClipperOffset::DoSquare(const Path64& path, size_t j, size_t k)
+{
+	PointD vec;
+	if (j == k)
+		vec = PointD(norms[j].y, -norms[j].x);
+	else
+		vec = GetAvgUnitVector(
+			PointD(-norms[k].y, norms[k].x),
+			PointD(norms[j].y, -norms[j].x));
+
+	double abs_delta = std::abs(group_delta_);
+
+	// now offset the original vertex delta units along unit vector
+	PointD ptQ = PointD(path[j]);
+	ptQ = TranslatePoint(ptQ, abs_delta * vec.x, abs_delta * vec.y);
+	// get perpendicular vertices
+	PointD pt1 = TranslatePoint(ptQ, group_delta_ * vec.y, group_delta_ * -vec.x);
+	PointD pt2 = TranslatePoint(ptQ, group_delta_ * -vec.y, group_delta_ * vec.x);
+	// get 2 vertices along one edge offset
+	PointD pt3 = GetPerpendicD(path[k], norms[k], group_delta_);
+	if (j == k)
+	{
+		PointD pt4 = PointD(pt3.x + vec.x * group_delta_, pt3.y + vec.y * group_delta_);
+		PointD pt = ptQ;
+		GetSegmentIntersectPt(pt1, pt2, pt3, pt4, pt);
+		//get the second intersect point through reflecion
+        path_out.emplace_back(ReflectPoint(pt, ptQ));
+        path_out.emplace_back(pt);
+	}
+	else
+	{
+		PointD pt4 = GetPerpendicD(path[j], norms[k], group_delta_);
+		PointD pt = ptQ;
+		GetSegmentIntersectPt(pt1, pt2, pt3, pt4, pt);
+        path_out.emplace_back(pt);
+		//get the second intersect point through reflecion
+        path_out.emplace_back(ReflectPoint(pt, ptQ));
+	}
+}
+
+void ClipperOffset::DoMiter(const Path64& path, size_t j, size_t k, double cos_a)
+{
+	double q = group_delta_ / (cos_a + 1);
+#ifdef USINGZ
+    path_out.emplace_back(
+		path[j].x + (norms[k].x + norms[j].x) * q,
+		path[j].y + (norms[k].y + norms[j].y) * q,
+        path[j].z);
+#else
+    path_out.emplace_back(
+		path[j].x + (norms[k].x + norms[j].x) * q,
+        path[j].y + (norms[k].y + norms[j].y) * q);
+#endif
+}
+
+void ClipperOffset::DoRound(const Path64& path, size_t j, size_t k, double angle)
+{
+	if (deltaCallback64_) {
+		// when deltaCallback64_ is assigned, group_delta_ won't be constant,
+		// so we'll need to do the following calculations for *every* vertex.
+		double abs_delta = std::fabs(group_delta_);
+		double arcTol = (arc_tolerance_ > floating_point_tolerance ?
+			std::min(abs_delta, arc_tolerance_) : abs_delta * arc_const);
+		double steps_per_360 = std::min(PI / std::acos(1 - arcTol / abs_delta), abs_delta * PI);
+		step_sin_ = std::sin(2 * PI / steps_per_360);
+		step_cos_ = std::cos(2 * PI / steps_per_360);
+		if (group_delta_ < 0.0) step_sin_ = -step_sin_;
+		steps_per_rad_ = steps_per_360 / (2 * PI);
+	}
+
+	Point64 pt = path[j];
+	PointD offsetVec = PointD(norms[k].x * group_delta_, norms[k].y * group_delta_);
+
+	if (j == k) offsetVec.Negate();
+#ifdef USINGZ
+    path_out.emplace_back(pt.x + offsetVec.x, pt.y + offsetVec.y, pt.z);
+#else
+    path_out.emplace_back(pt.x + offsetVec.x, pt.y + offsetVec.y);
+#endif
+	int steps = static_cast<int>(std::ceil(steps_per_rad_ * std::abs(angle))); // #448, #456
+	for (int i = 1; i < steps; ++i) // ie 1 less than steps
+	{
+		offsetVec = PointD(offsetVec.x * step_cos_ - step_sin_ * offsetVec.y,
+			offsetVec.x * step_sin_ + offsetVec.y * step_cos_);
+#ifdef USINGZ
+        path_out.emplace_back(pt.x + offsetVec.x, pt.y + offsetVec.y, pt.z);
+#else
+        path_out.emplace_back(pt.x + offsetVec.x, pt.y + offsetVec.y);
+#endif
+	}
+    path_out.emplace_back(GetPerpendic(path[j], norms[j], group_delta_));
+}
+
+void ClipperOffset::OffsetPoint(Group& group, const Path64& path, size_t j, size_t k)
+{
+	// Let A = change in angle where edges join
+	// A == 0: ie no change in angle (flat join)
+	// A == PI: edges 'spike'
+	// sin(A) < 0: right turning
+	// cos(A) < 0: change in angle is more than 90 degree
+
+	if (path[j] == path[k]) return;
+
+	double sin_a = CrossProduct(norms[j], norms[k]);
+	double cos_a = DotProduct(norms[j], norms[k]);
+	if (sin_a > 1.0) sin_a = 1.0;
+	else if (sin_a < -1.0) sin_a = -1.0;
+
+	if (deltaCallback64_) {
+		group_delta_ = deltaCallback64_(path, norms, j, k);
+		if (group.is_reversed) group_delta_ = -group_delta_;
+	}
+	if (std::fabs(group_delta_) <= floating_point_tolerance)
+	{
+        path_out.emplace_back(path[j]);
+		return;
+	}
+
+	if (cos_a > -0.999 && (sin_a * group_delta_ < 0)) // test for concavity first (#593)
+	{
+		// is concave
+		// by far the simplest way to construct concave joins, especially those joining very 
+		// short segments, is to insert 3 points that produce negative regions. These regions 
+		// will be removed later by the finishing union operation. This is also the best way 
+		// to ensure that path reversals (ie over-shrunk paths) are removed.
+#ifdef USINGZ
+        path_out.emplace_back(GetPerpendic(path[j], norms[k], group_delta_), path[j].z);
+        path_out.emplace_back(path[j]); // (#405, #873, #916)
+        path_out.emplace_back(GetPerpendic(path[j], norms[j], group_delta_), path[j].z);
+#else
+        path_out.emplace_back(GetPerpendic(path[j], norms[k], group_delta_));
+        path_out.emplace_back(path[j]); // (#405, #873, #916)
+        path_out.emplace_back(GetPerpendic(path[j], norms[j], group_delta_));
+#endif
+	}
+	else if (cos_a > 0.999 && join_type_ != JoinType::Round)
+	{
+		// almost straight - less than 2.5 degree (#424, #482, #526 & #724)
+		DoMiter(path, j, k, cos_a);
+	}
+	else if (join_type_ == JoinType::Miter)
+	{
+		// miter unless the angle is sufficiently acute to exceed ML
+		if (cos_a > temp_lim_ - 1) DoMiter(path, j, k, cos_a);
+		else DoSquare(path, j, k);
+	}
+	else if (join_type_ == JoinType::Round)
+		DoRound(path, j, k, std::atan2(sin_a, cos_a));
+	else if ( join_type_ == JoinType::Bevel)
+		DoBevel(path, j, k);
+	else
+		DoSquare(path, j, k);
+}
+
+void ClipperOffset::OffsetPolygon(Group& group, const Path64& path)
+{
+	path_out.clear();
+	for (Path64::size_type j = 0, k = path.size() - 1; j < path.size(); k = j, ++j)
+		OffsetPoint(group, path, j, k);	
+    solution->emplace_back(path_out);
+}
+
+void ClipperOffset::OffsetOpenJoined(Group& group, const Path64& path)
+{
+	OffsetPolygon(group, path);
+	Path64 reverse_path(path);
+	std::reverse(reverse_path.begin(), reverse_path.end());
+
+	//rebuild normals 
+	std::reverse(norms.begin(), norms.end());
+    norms.emplace_back(norms[0]);
+	norms.erase(norms.begin());
+	NegatePath(norms);
+
+	OffsetPolygon(group, reverse_path);
+}
+
+void ClipperOffset::OffsetOpenPath(Group& group, const Path64& path)
+{
+	// do the line start cap
+	if (deltaCallback64_) group_delta_ = deltaCallback64_(path, norms, 0, 0);
+
+	if (std::fabs(group_delta_) <= floating_point_tolerance)
+        path_out.emplace_back(path[0]);
+	else
+	{
+		switch (end_type_)
+		{
+		case EndType::Butt:
+			DoBevel(path, 0, 0);
+			break;
+		case EndType::Round:
+			DoRound(path, 0, 0, PI);
+			break;
+		default:
+			DoSquare(path, 0, 0);
+			break;
+		}
+	}
+
+	size_t highI = path.size() - 1;
+	// offset the left side going forward
+	for (Path64::size_type j = 1, k = 0; j < highI; k = j, ++j)
+		OffsetPoint(group, path, j, k);
+
+	// reverse normals
+	for (size_t i = highI; i > 0; --i)
+		norms[i] = PointD(-norms[i - 1].x, -norms[i - 1].y);
+	norms[0] = norms[highI];
+
+	// do the line end cap
+	if (deltaCallback64_)
+		group_delta_ = deltaCallback64_(path, norms, highI, highI);
+
+	if (std::fabs(group_delta_) <= floating_point_tolerance)
+        path_out.emplace_back(path[highI]);
+	else
+	{
+		switch (end_type_)
+		{
+		case EndType::Butt:
+			DoBevel(path, highI, highI);
+			break;
+		case EndType::Round:
+			DoRound(path, highI, highI, PI);
+			break;
+		default:
+			DoSquare(path, highI, highI);
+			break;
+		}
+	}
+
+	for (size_t j = highI -1, k = highI; j > 0; k = j, --j)
+		OffsetPoint(group, path, j, k);
+    solution->emplace_back(path_out);
+}
+
+void ClipperOffset::DoGroupOffset(Group& group)
+{
+	if (group.end_type == EndType::Polygon)
+	{
+		// a straight path (2 points) can now also be 'polygon' offset
+		// where the ends will be treated as (180 deg.) joins
+        if (!group.lowest_path_idx.has_value()) delta_ = std::abs(delta_);
+		group_delta_ = (group.is_reversed) ? -delta_ : delta_;
+	}
+	else
+		group_delta_ = std::abs(delta_);// *0.5;
+
+	double abs_delta = std::fabs(group_delta_);
+	join_type_	= group.join_type;
+	end_type_ = group.end_type;
+
+	if (group.join_type == JoinType::Round || group.end_type == EndType::Round)
+	{
+		// calculate the number of steps required to approximate a circle
+		// (see https://www.angusj.com/clipper2/Docs/Trigonometry.htm)
+		// arcTol - when arc_tolerance_ is undefined (0) then curve imprecision
+		// will be relative to the size of the offset (delta). Obviously very
+		//large offsets will almost always require much less precision.
+		double arcTol = (arc_tolerance_ > floating_point_tolerance) ?
+			std::min(abs_delta, arc_tolerance_) : abs_delta * arc_const;
+
+		double steps_per_360 = std::min(PI / std::acos(1 - arcTol / abs_delta), abs_delta * PI);
+		step_sin_ = std::sin(2 * PI / steps_per_360);
+		step_cos_ = std::cos(2 * PI / steps_per_360);
+		if (group_delta_ < 0.0) step_sin_ = -step_sin_;
+		steps_per_rad_ = steps_per_360 / (2 * PI);
+	}
+
+	//double min_area = PI * Sqr(group_delta_);
+	Paths64::const_iterator path_in_it = group.paths_in.cbegin();
+	for ( ; path_in_it != group.paths_in.cend(); ++path_in_it)
+	{
+		Path64::size_type pathLen = path_in_it->size();
+		path_out.clear();
+
+		if (pathLen == 1) // single point
+		{
+			if (deltaCallback64_)
+			{
+				group_delta_ = deltaCallback64_(*path_in_it, norms, 0, 0);
+				if (group.is_reversed) group_delta_ = -group_delta_;
+				abs_delta = std::fabs(group_delta_);
+			}
+
+			if (group_delta_ < 1) continue;
+			const Point64& pt = (*path_in_it)[0];
+			//single vertex so build a circle or square ...
+			if (group.join_type == JoinType::Round)
+			{
+				double radius = abs_delta;
+                size_t steps = steps_per_rad_ > 0 ? static_cast<size_t>(std::ceil(steps_per_rad_ * 2 * PI)) : 0; //#617
+				path_out = Ellipse(pt, radius, radius, steps);
+#ifdef USINGZ
+				for (auto& p : path_out) p.z = pt.z;
+#endif
+			}
+			else
+			{
+				int d = (int)std::ceil(abs_delta);
+				Rect64 r = Rect64(pt.x - d, pt.y - d, pt.x + d, pt.y + d);
+				path_out = r.AsPath();
+#ifdef USINGZ
+				for (auto& p : path_out) p.z = pt.z;
+#endif
+			}
+
+            solution->emplace_back(path_out);
+			continue;
+		} // end of offsetting a single point
+
+		if ((pathLen == 2) && (group.end_type == EndType::Joined))
+			end_type_ = (group.join_type == JoinType::Round) ?
+			  EndType::Round :
+			  EndType::Square;
+
+		BuildNormals(*path_in_it);
+		if (end_type_ == EndType::Polygon) OffsetPolygon(group, *path_in_it);
+		else if (end_type_ == EndType::Joined) OffsetOpenJoined(group, *path_in_it);
+		else OffsetOpenPath(group, *path_in_it);
+	}
+}
+
+#ifdef USINGZ
+void ClipperOffset::ZCB(const Point64& bot1, const Point64& top1,
+	const Point64& bot2, const Point64& top2, Point64& ip)
+{
+	if (bot1.z && ((bot1.z == bot2.z) || (bot1.z == top2.z))) ip.z = bot1.z;
+	else if (bot2.z && (bot2.z == top1.z)) ip.z = bot2.z;
+	else if (top1.z && (top1.z == top2.z)) ip.z = top1.z;
+	else if (zCallback64_) zCallback64_(bot1, top1, bot2, top2, ip);
+}
+#endif
+
+size_t ClipperOffset::CalcSolutionCapacity()
+{
+	size_t result = 0;
+	for (const Group& g : groups_)
+		result += (g.end_type == EndType::Joined) ? g.paths_in.size() * 2 : g.paths_in.size();
+	return result;
+}
+
+bool ClipperOffset::CheckReverseOrientation()
+{
+	// nb: this assumes there's consistency in orientation between groups
+	bool is_reversed_orientation = false;
+	for (const Group& g : groups_)
+		if (g.end_type == EndType::Polygon)
+		{
+			is_reversed_orientation = g.is_reversed;
+			break;
+		}
+	return is_reversed_orientation;
+}
+
+void ClipperOffset::ExecuteInternal(double delta)
+{
+	error_code_ = 0;
+	if (groups_.size() == 0) return;
+	solution->reserve(CalcSolutionCapacity());
+
+	if (std::abs(delta) < 0.5) // ie: offset is insignificant
+	{
+		Paths64::size_type sol_size = 0;
+		for (const Group& group : groups_) sol_size += group.paths_in.size();
+		solution->reserve(sol_size);
+		for (const Group& group : groups_)
+			copy(group.paths_in.begin(), group.paths_in.end(), back_inserter(*solution));
+	}
+	else
+	{
+
+		temp_lim_ = (miter_limit_ <= 1) ?
+			2.0 :
+			2.0 / (miter_limit_ * miter_limit_);
+
+		delta_ = delta;
+		std::vector<Group>::iterator git;
+		for (git = groups_.begin(); git != groups_.end(); ++git)
+		{
+			DoGroupOffset(*git);
+			if (!error_code_) continue; // all OK
+			solution->clear();
+		}
+	}
+
+	if (!solution->size()) return;
+
+	bool paths_reversed = CheckReverseOrientation();
+	//clean up self-intersections ...
+	Clipper64 c;
+	c.PreserveCollinear(preserve_collinear_);
+	//the solution should retain the orientation of the input
+	c.ReverseSolution(reverse_solution_ != paths_reversed);
+#ifdef USINGZ
+	auto fp = std::bind(&ClipperOffset::ZCB, this, std::placeholders::_1,
+		std::placeholders::_2, std::placeholders::_3,
+		std::placeholders::_4, std::placeholders::_5);
+	c.SetZCallback(fp);
+#endif
+	c.AddSubject(*solution);
+	if (solution_tree)
+	{
+		if (paths_reversed)
+			c.Execute(ClipType::Union, FillRule::Negative, *solution_tree);
+		else
+			c.Execute(ClipType::Union, FillRule::Positive, *solution_tree);
+	}
+	else
+	{
+		if (paths_reversed)
+			c.Execute(ClipType::Union, FillRule::Negative, *solution);
+		else
+			c.Execute(ClipType::Union, FillRule::Positive, *solution);
+	}
+}
+
+void ClipperOffset::Execute(double delta, Paths64& paths64)
+{
+	paths64.clear();
+	solution = &paths64;
+	solution_tree = nullptr;
+	ExecuteInternal(delta);
+}
+
+
+void ClipperOffset::Execute(double delta, PolyTree64& polytree)
+{
+	polytree.Clear();
+	solution_tree = &polytree;
+	solution = new Paths64();
+	ExecuteInternal(delta);
+	delete solution;
+	solution = nullptr;
+}
+
+void ClipperOffset::Execute(DeltaCallback64 delta_cb, Paths64& paths)
+{
+	deltaCallback64_ = delta_cb;
+	Execute(1.0, paths);
+}
+
+} // namespace

--- a/FrameDirector/third_party/clipper2/src/clipper.rectclip.cpp
+++ b/FrameDirector/third_party/clipper2/src/clipper.rectclip.cpp
@@ -1,0 +1,1027 @@
+/*******************************************************************************
+* Author    :  Angus Johnson                                                   *
+* Date      :  5 July 2024                                                     *
+* Website   :  https://www.angusj.com                                          *
+* Copyright :  Angus Johnson 2010-2024                                         *
+* Purpose   :  FAST rectangular clipping                                       *
+* License   :  https://www.boost.org/LICENSE_1_0.txt                           *
+*******************************************************************************/
+
+#include "clipper2/clipper.h"
+#include "clipper2/clipper.rectclip.h"
+
+namespace Clipper2Lib {
+
+  //------------------------------------------------------------------------------
+  // Miscellaneous methods
+  //------------------------------------------------------------------------------
+
+  inline bool Path1ContainsPath2(const Path64& path1, const Path64& path2)
+  {
+    int io_count = 0;
+    // precondition: no (significant) overlap
+    for (const Point64& pt : path2)
+    {
+      PointInPolygonResult pip = PointInPolygon(pt, path1);
+      switch (pip)
+      {
+      case PointInPolygonResult::IsOutside: ++io_count; break;
+      case PointInPolygonResult::IsInside: --io_count; break;
+      default: continue;
+      }
+      if (std::abs(io_count) > 1) break;
+    }
+    return io_count <= 0;
+  }
+
+  inline bool GetLocation(const Rect64& rec,
+    const Point64& pt, Location& loc)
+  {
+    if (pt.x == rec.left && pt.y >= rec.top && pt.y <= rec.bottom)
+    {
+      loc = Location::Left;
+      return false;
+    }
+    else if (pt.x == rec.right && pt.y >= rec.top && pt.y <= rec.bottom)
+    {
+      loc = Location::Right;
+      return false;
+    }
+    else if (pt.y == rec.top && pt.x >= rec.left && pt.x <= rec.right)
+    {
+      loc = Location::Top;
+      return false;
+    }
+    else if (pt.y == rec.bottom && pt.x >= rec.left && pt.x <= rec.right)
+    {
+      loc = Location::Bottom;
+      return false;
+    }
+    else if (pt.x < rec.left) loc = Location::Left;
+    else if (pt.x > rec.right) loc = Location::Right;
+    else if (pt.y < rec.top) loc = Location::Top;
+    else if (pt.y > rec.bottom) loc = Location::Bottom;
+    else loc = Location::Inside;
+    return true;
+  }
+
+  inline bool IsHorizontal(const Point64& pt1, const Point64& pt2)
+  {
+    return pt1.y == pt2.y;
+  }
+
+  bool GetSegmentIntersection(const Point64& p1,
+    const Point64& p2, const Point64& p3, const Point64& p4, Point64& ip)
+  {
+    double res1 = CrossProduct(p1, p3, p4);
+    double res2 = CrossProduct(p2, p3, p4);
+    if (res1 == 0)
+    {
+      ip = p1;
+      if (res2 == 0) return false; // segments are collinear
+      else if (p1 == p3 || p1 == p4) return true;
+      //else if (p2 == p3 || p2 == p4) { ip = p2; return true; }
+      else if (IsHorizontal(p3, p4)) return ((p1.x > p3.x) == (p1.x < p4.x));
+      else return ((p1.y > p3.y) == (p1.y < p4.y));
+    }
+    else if (res2 == 0)
+    {
+      ip = p2;
+      if (p2 == p3 || p2 == p4) return true;
+      else if (IsHorizontal(p3, p4)) return ((p2.x > p3.x) == (p2.x < p4.x));
+      else return ((p2.y > p3.y) == (p2.y < p4.y));
+    }
+    if ((res1 > 0) == (res2 > 0)) return false;
+
+    double res3 = CrossProduct(p3, p1, p2);
+    double res4 = CrossProduct(p4, p1, p2);
+    if (res3 == 0)
+    {
+      ip = p3;
+      if (p3 == p1 || p3 == p2) return true;
+      else if (IsHorizontal(p1, p2)) return ((p3.x > p1.x) == (p3.x < p2.x));
+      else return ((p3.y > p1.y) == (p3.y < p2.y));
+    }
+    else if (res4 == 0)
+    {
+      ip = p4;
+      if (p4 == p1 || p4 == p2) return true;
+      else if (IsHorizontal(p1, p2)) return ((p4.x > p1.x) == (p4.x < p2.x));
+      else return ((p4.y > p1.y) == (p4.y < p2.y));
+    }
+    if ((res3 > 0) == (res4 > 0)) return false;
+
+    // segments must intersect to get here
+    return GetSegmentIntersectPt(p1, p2, p3, p4, ip);
+  }
+
+  inline bool GetIntersection(const Path64& rectPath,
+    const Point64& p, const Point64& p2, Location& loc, Point64& ip)
+  {
+    // gets the intersection closest to 'p'
+    // when Result = false, loc will remain unchanged
+    switch (loc)
+    {
+    case Location::Left:
+      if (GetSegmentIntersection(p, p2, rectPath[0], rectPath[3], ip)) return true;
+      else if ((p.y < rectPath[0].y) && GetSegmentIntersection(p, p2, rectPath[0], rectPath[1], ip))
+      {
+        loc = Location::Top;
+        return true;
+      }
+      else if (GetSegmentIntersection(p, p2, rectPath[2], rectPath[3], ip))
+      {
+        loc = Location::Bottom;
+        return true;
+      }
+      else return false;
+
+    case Location::Top:
+      if (GetSegmentIntersection(p, p2, rectPath[0], rectPath[1], ip)) return true;
+      else if ((p.x < rectPath[0].x) && GetSegmentIntersection(p, p2, rectPath[0], rectPath[3], ip))
+      {
+        loc = Location::Left;
+        return true;
+      }
+      else if (GetSegmentIntersection(p, p2, rectPath[1], rectPath[2], ip))
+      {
+        loc = Location::Right;
+        return true;
+      }
+      else return false;
+
+    case Location::Right:
+      if (GetSegmentIntersection(p, p2, rectPath[1], rectPath[2], ip)) return true;
+      else if ((p.y < rectPath[1].y) && GetSegmentIntersection(p, p2, rectPath[0], rectPath[1], ip))
+      {
+        loc = Location::Top;
+        return true;
+      }
+      else if (GetSegmentIntersection(p, p2, rectPath[2], rectPath[3], ip))
+      {
+        loc = Location::Bottom;
+        return true;
+      }
+      else return false;
+
+    case Location::Bottom:
+      if (GetSegmentIntersection(p, p2, rectPath[2], rectPath[3], ip)) return true;
+      else if ((p.x < rectPath[3].x) && GetSegmentIntersection(p, p2, rectPath[0], rectPath[3], ip))
+      {
+        loc = Location::Left;
+        return true;
+      }
+      else if (GetSegmentIntersection(p, p2, rectPath[1], rectPath[2], ip))
+      {
+        loc = Location::Right;
+        return true;
+      }
+      else return false;
+
+    default: // loc == rInside
+      if (GetSegmentIntersection(p, p2, rectPath[0], rectPath[3], ip))
+      {
+        loc = Location::Left;
+        return true;
+      }
+      else if (GetSegmentIntersection(p, p2, rectPath[0], rectPath[1], ip))
+      {
+        loc = Location::Top;
+        return true;
+      }
+      else if (GetSegmentIntersection(p, p2, rectPath[1], rectPath[2], ip))
+      {
+        loc = Location::Right;
+        return true;
+      }
+      else if (GetSegmentIntersection(p, p2, rectPath[2], rectPath[3], ip))
+      {
+        loc = Location::Bottom;
+        return true;
+      }
+      else return false;
+    }
+  }
+
+  inline Location GetAdjacentLocation(Location loc, bool isClockwise)
+  {
+    int delta = (isClockwise) ? 1 : 3;
+    return static_cast<Location>((static_cast<int>(loc) + delta) % 4);
+  }
+
+  inline bool HeadingClockwise(Location prev, Location curr)
+  {
+    return (static_cast<int>(prev) + 1) % 4 == static_cast<int>(curr);
+  }
+
+  inline bool AreOpposites(Location prev, Location curr)
+  {
+    return abs(static_cast<int>(prev) - static_cast<int>(curr)) == 2;
+  }
+
+  inline bool IsClockwise(Location prev, Location curr,
+    const Point64& prev_pt, const Point64& curr_pt, const Point64& rect_mp)
+  {
+    if (AreOpposites(prev, curr))
+      return CrossProduct(prev_pt, rect_mp, curr_pt) < 0;
+    else
+      return HeadingClockwise(prev, curr);
+  }
+
+  inline OutPt2* UnlinkOp(OutPt2* op)
+  {
+    if (op->next == op) return nullptr;
+    op->prev->next = op->next;
+    op->next->prev = op->prev;
+    return op->next;
+  }
+
+  inline OutPt2* UnlinkOpBack(OutPt2* op)
+  {
+    if (op->next == op) return nullptr;
+    op->prev->next = op->next;
+    op->next->prev = op->prev;
+    return op->prev;
+  }
+
+  inline uint32_t GetEdgesForPt(const Point64& pt, const Rect64& rec)
+  {
+    uint32_t result = 0;
+    if (pt.x == rec.left) result = 1;
+    else if (pt.x == rec.right) result = 4;
+    if (pt.y == rec.top) result += 2;
+    else if (pt.y == rec.bottom) result += 8;
+    return result;
+  }
+
+  inline bool IsHeadingClockwise(const Point64& pt1, const Point64& pt2, int edgeIdx)
+  {
+    switch (edgeIdx)
+    {
+    case 0: return pt2.y < pt1.y;
+    case 1: return pt2.x > pt1.x;
+    case 2: return pt2.y > pt1.y;
+    default: return pt2.x < pt1.x;
+    }
+  }
+
+  inline bool HasHorzOverlap(const Point64& left1, const Point64& right1,
+    const Point64& left2, const Point64& right2)
+  {
+    return (left1.x < right2.x) && (right1.x > left2.x);
+  }
+
+  inline bool HasVertOverlap(const Point64& top1, const Point64& bottom1,
+    const Point64& top2, const Point64& bottom2)
+  {
+    return (top1.y < bottom2.y) && (bottom1.y > top2.y);
+  }
+
+  inline void AddToEdge(OutPt2List& edge, OutPt2* op)
+  {
+    if (op->edge) return;
+    op->edge = &edge;
+    edge.emplace_back(op);
+  }
+
+  inline void UncoupleEdge(OutPt2* op)
+  {
+    if (!op->edge) return;
+    for (size_t i = 0; i < op->edge->size(); ++i)
+    {
+      OutPt2* op2 = (*op->edge)[i];
+      if (op2 == op)
+      {
+        (*op->edge)[i] = nullptr;
+        break;
+      }
+    }
+    op->edge = nullptr;
+  }
+
+  inline void SetNewOwner(OutPt2* op, size_t new_idx)
+  {
+    op->owner_idx = new_idx;
+    OutPt2* op2 = op->next;
+    while (op2 != op)
+    {
+      op2->owner_idx = new_idx;
+      op2 = op2->next;
+    }
+  }
+
+  //----------------------------------------------------------------------------
+  // RectClip64
+  //----------------------------------------------------------------------------
+
+  OutPt2* RectClip64::Add(Point64 pt, bool start_new)
+  {
+    // this method is only called by InternalExecute.
+    // Later splitting & rejoining won't create additional op's,
+    // though they will change the (non-storage) results_ count.
+    size_t curr_idx = results_.size();
+    OutPt2* result;
+    if (curr_idx == 0 || start_new)
+    {
+      result = &op_container_.emplace_back(OutPt2());
+      result->pt = pt;
+      result->next = result;
+      result->prev = result;
+      results_.emplace_back(result);
+    }
+    else
+    {
+      --curr_idx;
+      OutPt2* prevOp = results_[curr_idx];
+      if (prevOp->pt == pt)  return prevOp;
+      result = &op_container_.emplace_back(OutPt2());
+      result->owner_idx = curr_idx;
+      result->pt = pt;
+      result->next = prevOp->next;
+      prevOp->next->prev = result;
+      prevOp->next = result;
+      result->prev = prevOp;
+      results_[curr_idx] = result;
+    }
+    return result;
+  }
+
+  void RectClip64::AddCorner(Location prev, Location curr)
+  {
+    if (HeadingClockwise(prev, curr))
+      Add(rect_as_path_[static_cast<size_t>(prev)]);
+    else
+      Add(rect_as_path_[static_cast<size_t>(curr)]);
+  }
+
+  void RectClip64::AddCorner(Location& loc, bool isClockwise)
+  {
+    if (isClockwise)
+    {
+      Add(rect_as_path_[static_cast<size_t>(loc)]);
+      loc = GetAdjacentLocation(loc, true);
+    }
+    else
+    {
+      loc = GetAdjacentLocation(loc, false);
+      Add(rect_as_path_[static_cast<size_t>(loc)]);
+    }
+  }
+
+  void RectClip64::GetNextLocation(const Path64& path,
+    Location& loc, size_t& i, size_t highI)
+  {
+    switch (loc)
+    {
+    case Location::Left:
+      while (i <= highI && path[i].x <= rect_.left) ++i;
+      if (i > highI) break;
+      else if (path[i].x >= rect_.right) loc = Location::Right;
+      else if (path[i].y <= rect_.top) loc = Location::Top;
+      else if (path[i].y >= rect_.bottom) loc = Location::Bottom;
+      else loc = Location::Inside;
+      break;
+
+    case Location::Top:
+      while (i <= highI && path[i].y <= rect_.top) ++i;
+      if (i > highI) break;
+      else if (path[i].y >= rect_.bottom) loc = Location::Bottom;
+      else if (path[i].x <= rect_.left) loc = Location::Left;
+      else if (path[i].x >= rect_.right) loc = Location::Right;
+      else loc = Location::Inside;
+      break;
+
+    case Location::Right:
+      while (i <= highI && path[i].x >= rect_.right) ++i;
+      if (i > highI) break;
+      else if (path[i].x <= rect_.left) loc = Location::Left;
+      else if (path[i].y <= rect_.top) loc = Location::Top;
+      else if (path[i].y >= rect_.bottom) loc = Location::Bottom;
+      else loc = Location::Inside;
+      break;
+
+    case Location::Bottom:
+      while (i <= highI && path[i].y >= rect_.bottom) ++i;
+      if (i > highI) break;
+      else if (path[i].y <= rect_.top) loc = Location::Top;
+      else if (path[i].x <= rect_.left) loc = Location::Left;
+      else if (path[i].x >= rect_.right) loc = Location::Right;
+      else loc = Location::Inside;
+      break;
+
+    case Location::Inside:
+      while (i <= highI)
+      {
+        if (path[i].x < rect_.left) loc = Location::Left;
+        else if (path[i].x > rect_.right) loc = Location::Right;
+        else if (path[i].y > rect_.bottom) loc = Location::Bottom;
+        else if (path[i].y < rect_.top) loc = Location::Top;
+        else { Add(path[i]); ++i; continue; }
+        break; //inner loop
+      }
+      break;
+    } //switch
+  }
+
+  bool StartLocsAreClockwise(const std::vector<Location>& startlocs)
+  {
+    int result = 0;
+    for (size_t i = 1; i < startlocs.size(); ++i)
+    {
+      int d = static_cast<int>(startlocs[i]) - static_cast<int>(startlocs[i - 1]);
+      switch (d)
+      {
+        case -1: result -= 1; break;
+        case 1: result += 1; break;
+        case -3: result += 1; break;
+        case 3: result -= 1; break;
+      }
+    }
+    return result > 0;
+  }
+
+  void RectClip64::ExecuteInternal(const Path64& path)
+  {
+    if (path.size() < 1)
+      return;
+
+    size_t highI = path.size() - 1;
+    Location prev = Location::Inside, loc;
+    Location crossing_loc = Location::Inside;
+    Location first_cross_ = Location::Inside;
+    if (!GetLocation(rect_, path[highI], loc))
+    {
+      size_t i = highI;
+      while (i > 0 && !GetLocation(rect_, path[i - 1], prev))
+        --i;
+      if (i == 0)
+      {
+        // all of path must be inside fRect
+        for (const auto& pt : path) Add(pt);
+        return;
+      }
+      if (prev == Location::Inside) loc = Location::Inside;
+    }
+    Location starting_loc = loc;
+
+    ///////////////////////////////////////////////////
+    size_t i = 0;
+    while (i <= highI)
+    {
+      prev = loc;
+      Location crossing_prev = crossing_loc;
+
+      GetNextLocation(path, loc, i, highI);
+
+      if (i > highI) break;
+      Point64 ip, ip2;
+      Point64 prev_pt = (i) ?
+        path[static_cast<size_t>(i - 1)] :
+        path[highI];
+
+      crossing_loc = loc;
+      if (!GetIntersection(rect_as_path_,
+        path[i], prev_pt, crossing_loc, ip))
+      {
+        // ie remaining outside
+        if (crossing_prev == Location::Inside)
+        {
+          bool isClockw = IsClockwise(prev, loc, prev_pt, path[i], rect_mp_);
+          do {
+            start_locs_.emplace_back(prev);
+            prev = GetAdjacentLocation(prev, isClockw);
+          } while (prev != loc);
+          crossing_loc = crossing_prev; // still not crossed
+        }
+        else if (prev != Location::Inside && prev != loc)
+        {
+          bool isClockw = IsClockwise(prev, loc, prev_pt, path[i], rect_mp_);
+          do {
+            AddCorner(prev, isClockw);
+          } while (prev != loc);
+        }
+        ++i;
+        continue;
+      }
+
+      ////////////////////////////////////////////////////
+      // we must be crossing the rect boundary to get here
+      ////////////////////////////////////////////////////
+
+      if (loc == Location::Inside) // path must be entering rect
+      {
+        if (first_cross_ == Location::Inside)
+        {
+          first_cross_ = crossing_loc;
+          start_locs_.emplace_back(prev);
+        }
+        else if (prev != crossing_loc)
+        {
+          bool isClockw = IsClockwise(prev, crossing_loc, prev_pt, path[i], rect_mp_);
+          do {
+            AddCorner(prev, isClockw);
+          } while (prev != crossing_loc);
+        }
+      }
+      else if (prev != Location::Inside)
+      {
+        // passing right through rect. 'ip' here will be the second
+        // intersect pt but we'll also need the first intersect pt (ip2)
+        loc = prev;
+        GetIntersection(rect_as_path_, prev_pt, path[i], loc, ip2);
+        if (crossing_prev != Location::Inside && crossing_prev != loc) //579
+          AddCorner(crossing_prev, loc);
+
+        if (first_cross_ == Location::Inside)
+        {
+          first_cross_ = loc;
+          start_locs_.emplace_back(prev);
+        }
+
+        loc = crossing_loc;
+        Add(ip2);
+        if (ip == ip2)
+        {
+          // it's very likely that path[i] is on rect
+          GetLocation(rect_, path[i], loc);
+          AddCorner(crossing_loc, loc);
+          crossing_loc = loc;
+          continue;
+        }
+      }
+      else // path must be exiting rect
+      {
+        loc = crossing_loc;
+        if (first_cross_ == Location::Inside)
+          first_cross_ = crossing_loc;
+      }
+
+      Add(ip);
+
+    } //while i <= highI
+    ///////////////////////////////////////////////////
+
+    if (first_cross_ == Location::Inside)
+    {
+      // path never intersects
+      if (starting_loc != Location::Inside)
+      {
+        // path is outside rect
+        // but being outside, it still may not contain rect
+        if (path_bounds_.Contains(rect_) &&
+          Path1ContainsPath2(path, rect_as_path_))
+        {
+          // yep, the path does fully contain rect
+          // so add rect to the solution
+          bool is_clockwise_path = StartLocsAreClockwise(start_locs_);
+          for (size_t j = 0; j < 4; ++j)
+          {
+            size_t k = is_clockwise_path ? j : 3 - j; // reverses result path
+            Add(rect_as_path_[k]);
+            // we may well need to do some splitting later, so
+            AddToEdge(edges_[k * 2], results_[0]);
+          }
+        }
+      }
+    }
+    else if (loc != Location::Inside &&
+      (loc != first_cross_ || start_locs_.size() > 2))
+    {
+      if (start_locs_.size() > 0)
+      {
+        prev = loc;
+        for (auto loc2 : start_locs_)
+        {
+          if (prev == loc2) continue;
+          AddCorner(prev, HeadingClockwise(prev, loc2));
+          prev = loc2;
+        }
+        loc = prev;
+      }
+      if (loc != first_cross_)
+        AddCorner(loc, HeadingClockwise(loc, first_cross_));
+    }
+  }
+
+  void RectClip64::CheckEdges()
+  {
+    for (size_t i = 0; i < results_.size(); ++i)
+    {
+      OutPt2* op = results_[i];
+      if (!op) continue;
+      OutPt2* op2 = op;
+      do
+      {
+        if (IsCollinear(op2->prev->pt, op2->pt, op2->next->pt))
+        {
+          if (op2 == op)
+          {
+            op2 = UnlinkOpBack(op2);
+            if (!op2) break;
+            op = op2->prev;
+          }
+          else
+          {
+            op2 = UnlinkOpBack(op2);
+            if (!op2) break;
+          }
+        }
+        else
+          op2 = op2->next;
+      } while (op2 != op);
+
+      if (!op2)
+      {
+        results_[i] = nullptr;
+        continue;
+      }
+      results_[i] = op; // safety first
+
+      uint32_t edgeSet1 = GetEdgesForPt(op->prev->pt, rect_);
+      op2 = op;
+      do
+      {
+        uint32_t edgeSet2 = GetEdgesForPt(op2->pt, rect_);
+        if (edgeSet2 && !op2->edge)
+        {
+          uint32_t combinedSet = (edgeSet1 & edgeSet2);
+          for (int j = 0; j < 4; ++j)
+          {
+            if (combinedSet & (1 << j))
+            {
+              if (IsHeadingClockwise(op2->prev->pt, op2->pt, j))
+                AddToEdge(edges_[j * 2], op2);
+              else
+                AddToEdge(edges_[j * 2 + 1], op2);
+            }
+          }
+        }
+        edgeSet1 = edgeSet2;
+        op2 = op2->next;
+      } while (op2 != op);
+    }
+  }
+
+  void RectClip64::TidyEdges(size_t idx, OutPt2List& cw, OutPt2List& ccw)
+  {
+    if (ccw.empty()) return;
+    bool isHorz = ((idx == 1) || (idx == 3));
+    bool cwIsTowardLarger = ((idx == 1) || (idx == 2));
+    size_t i = 0, j = 0;
+    OutPt2* p1, * p2, * p1a, * p2a, * op, * op2;
+
+    while (i < cw.size())
+    {
+      p1 = cw[i];
+      if (!p1 || p1->next == p1->prev)
+      {
+        cw[i++] = nullptr;
+        j = 0;
+        continue;
+      }
+
+      size_t jLim = ccw.size();
+      while (j < jLim &&
+        (!ccw[j] || ccw[j]->next == ccw[j]->prev)) ++j;
+
+      if (j == jLim)
+      {
+        ++i;
+        j = 0;
+        continue;
+      }
+
+      if (cwIsTowardLarger)
+      {
+        // p1 >>>> p1a;
+        // p2 <<<< p2a;
+        p1 = cw[i]->prev;
+        p1a = cw[i];
+        p2 = ccw[j];
+        p2a = ccw[j]->prev;
+      }
+      else
+      {
+        // p1 <<<< p1a;
+        // p2 >>>> p2a;
+        p1 = cw[i];
+        p1a = cw[i]->prev;
+        p2 = ccw[j]->prev;
+        p2a = ccw[j];
+      }
+
+      if ((isHorz && !HasHorzOverlap(p1->pt, p1a->pt, p2->pt, p2a->pt)) ||
+        (!isHorz && !HasVertOverlap(p1->pt, p1a->pt, p2->pt, p2a->pt)))
+      {
+        ++j;
+        continue;
+      }
+
+      // to get here we're either splitting or rejoining
+      bool isRejoining = cw[i]->owner_idx != ccw[j]->owner_idx;
+
+      if (isRejoining)
+      {
+        results_[p2->owner_idx] = nullptr;
+        SetNewOwner(p2, p1->owner_idx);
+      }
+
+      // do the split or re-join
+      if (cwIsTowardLarger)
+      {
+        // p1 >> | >> p1a;
+        // p2 << | << p2a;
+        p1->next = p2;
+        p2->prev = p1;
+        p1a->prev = p2a;
+        p2a->next = p1a;
+      }
+      else
+      {
+        // p1 << | << p1a;
+        // p2 >> | >> p2a;
+        p1->prev = p2;
+        p2->next = p1;
+        p1a->next = p2a;
+        p2a->prev = p1a;
+      }
+
+      if (!isRejoining)
+      {
+        size_t new_idx = results_.size();
+        results_.emplace_back(p1a);
+        SetNewOwner(p1a, new_idx);
+      }
+
+      if (cwIsTowardLarger)
+      {
+        op = p2;
+        op2 = p1a;
+      }
+      else
+      {
+        op = p1;
+        op2 = p2a;
+      }
+      results_[op->owner_idx] = op;
+      results_[op2->owner_idx] = op2;
+
+      // and now lots of work to get ready for the next loop
+
+      bool opIsLarger, op2IsLarger;
+      if (isHorz) // X
+      {
+        opIsLarger = op->pt.x > op->prev->pt.x;
+        op2IsLarger = op2->pt.x > op2->prev->pt.x;
+      }
+      else       // Y
+      {
+        opIsLarger = op->pt.y > op->prev->pt.y;
+        op2IsLarger = op2->pt.y > op2->prev->pt.y;
+      }
+
+      if ((op->next == op->prev) ||
+        (op->pt == op->prev->pt))
+      {
+        if (op2IsLarger == cwIsTowardLarger)
+        {
+          cw[i] = op2;
+          ccw[j++] = nullptr;
+        }
+        else
+        {
+          ccw[j] = op2;
+          cw[i++] = nullptr;
+        }
+      }
+      else if ((op2->next == op2->prev) ||
+        (op2->pt == op2->prev->pt))
+      {
+        if (opIsLarger == cwIsTowardLarger)
+        {
+          cw[i] = op;
+          ccw[j++] = nullptr;
+        }
+        else
+        {
+          ccw[j] = op;
+          cw[i++] = nullptr;
+        }
+      }
+      else if (opIsLarger == op2IsLarger)
+      {
+        if (opIsLarger == cwIsTowardLarger)
+        {
+          cw[i] = op;
+          UncoupleEdge(op2);
+          AddToEdge(cw, op2);
+          ccw[j++] = nullptr;
+        }
+        else
+        {
+          cw[i++] = nullptr;
+          ccw[j] = op2;
+          UncoupleEdge(op);
+          AddToEdge(ccw, op);
+          j = 0;
+        }
+      }
+      else
+      {
+        if (opIsLarger == cwIsTowardLarger)
+          cw[i] = op;
+        else
+          ccw[j] = op;
+        if (op2IsLarger == cwIsTowardLarger)
+          cw[i] = op2;
+        else
+          ccw[j] = op2;
+      }
+    }
+  }
+
+  Path64 RectClip64::GetPath(OutPt2*& op)
+  {
+    if (!op || op->next == op->prev) return Path64();
+
+    OutPt2* op2 = op->next;
+    while (op2 && op2 != op)
+    {
+      if (IsCollinear(op2->prev->pt,
+        op2->pt, op2->next->pt))
+      {
+        op = op2->prev;
+        op2 = UnlinkOp(op2);
+      }
+      else
+        op2 = op2->next;
+    }
+    op = op2; // needed for op cleanup
+    if (!op2) return Path64();
+
+    Path64 result;
+    result.emplace_back(op->pt);
+    op2 = op->next;
+    while (op2 != op)
+    {
+      result.emplace_back(op2->pt);
+      op2 = op2->next;
+    }
+    return result;
+  }
+
+  Paths64 RectClip64::Execute(const Paths64& paths)
+  {
+    Paths64 result;
+    if (rect_.IsEmpty()) return result;
+
+    for (const Path64& path : paths)
+    {
+      if (path.size() < 3) continue;
+      path_bounds_ = GetBounds(path);
+      if (!rect_.Intersects(path_bounds_))
+        continue; // the path must be completely outside rect_
+      else if (rect_.Contains(path_bounds_))
+      {
+        // the path must be completely inside rect_
+        result.emplace_back(path);
+        continue;
+      }
+
+      ExecuteInternal(path);
+      CheckEdges();
+      for (size_t i = 0; i < 4; ++i)
+        TidyEdges(i, edges_[i * 2], edges_[i * 2 + 1]);
+
+      for (OutPt2*& op :  results_)
+      {
+        Path64 tmp = GetPath(op);
+        if (!tmp.empty())
+          result.emplace_back(std::move(tmp));
+      }
+
+      //clean up after every loop
+      op_container_ = std::deque<OutPt2>();
+      results_.clear();
+      for (OutPt2List &edge : edges_) edge.clear();
+      start_locs_.clear();
+    }
+    return result;
+  }
+
+  //------------------------------------------------------------------------------
+  // RectClipLines64
+  //------------------------------------------------------------------------------
+
+  Paths64 RectClipLines64::Execute(const Paths64& paths)
+  {
+    Paths64 result;
+    if (rect_.IsEmpty()) return result;
+
+    for (const auto& path : paths)
+    {
+      Rect64 pathrec = GetBounds(path);
+      if (!rect_.Intersects(pathrec)) continue;
+
+      ExecuteInternal(path);
+
+      for (OutPt2*& op : results_)
+      {
+        Path64 tmp = GetPath(op);
+        if (!tmp.empty())
+          result.emplace_back(std::move(tmp));
+      }
+      results_.clear();
+
+      op_container_ = std::deque<OutPt2>();
+      start_locs_.clear();
+    }
+    return result;
+  }
+
+  void RectClipLines64::ExecuteInternal(const Path64& path)
+  {
+    if (rect_.IsEmpty() || path.size() < 2) return;
+
+    results_.clear();
+    op_container_ = std::deque<OutPt2>();
+    start_locs_.clear();
+
+    size_t i = 1, highI = path.size() - 1;
+
+    Location prev = Location::Inside, loc;
+    Location crossing_loc;
+    if (!GetLocation(rect_, path[0], loc))
+    {
+      while (i <= highI && !GetLocation(rect_, path[i], prev)) ++i;
+      if (i > highI)
+      {
+        // all of path must be inside fRect
+        for (const auto& pt : path) Add(pt);
+        return;
+      }
+      if (prev == Location::Inside) loc = Location::Inside;
+      i = 1;
+    }
+    if (loc == Location::Inside) Add(path[0]);
+
+    ///////////////////////////////////////////////////
+    while (i <= highI)
+    {
+      prev = loc;
+      GetNextLocation(path, loc, i, highI);
+      if (i > highI) break;
+      Point64 ip, ip2;
+      Point64 prev_pt = path[static_cast<size_t>(i - 1)];
+
+      crossing_loc = loc;
+      if (!GetIntersection(rect_as_path_,
+        path[i], prev_pt, crossing_loc, ip))
+      {
+        // ie remaining outside
+        ++i;
+        continue;
+      }
+
+      ////////////////////////////////////////////////////
+      // we must be crossing the rect boundary to get here
+      ////////////////////////////////////////////////////
+
+      if (loc == Location::Inside) // path must be entering rect
+      {
+        Add(ip, true);
+      }
+      else if (prev != Location::Inside)
+      {
+        // passing right through rect. 'ip' here will be the second
+        // intersect pt but we'll also need the first intersect pt (ip2)
+        crossing_loc = prev;
+        GetIntersection(rect_as_path_,
+          prev_pt, path[i], crossing_loc, ip2);
+        Add(ip2, true);
+        Add(ip);
+      }
+      else // path must be exiting rect
+      {
+        Add(ip);
+      }
+    } //while i <= highI
+    ///////////////////////////////////////////////////
+  }
+
+  Path64 RectClipLines64::GetPath(OutPt2*& op)
+  {
+    Path64 result;
+    if (!op || op == op->next) return result;
+    op = op->next; // starting at path beginning
+    result.emplace_back(op->pt);
+    OutPt2 *op2 = op->next;
+    while (op2 != op)
+    {
+      result.emplace_back(op2->pt);
+      op2 = op2->next;
+    }
+    return result;
+  }
+
+} // namespace


### PR DESCRIPTION
## Summary
- remove the temporary Clipper2 stubs from the bucket fill tool so real geometry ops can run
- vendor the Clipper2 engine, offset, and rect clip sources into third_party and add them to the build
- update the project configuration to include the third_party headers when compiling

## Testing
- not run (Windows-only project)

------
https://chatgpt.com/codex/tasks/task_e_68d161783b748321a981712fc6b79247