### PR TITLE
Fix bucket fill recognition for complex stroke regions

### DIFF
--- a/FrameDirector/BucketFillTool.h
+++ b/FrameDirector/BucketFillTool.h
@@ -14,6 +14,8 @@
 #include <QTimer>
 #include <QRectF>
 
+#include "third_party/clipper.h"
+
 class BucketFillTool : public Tool
 {
     Q_OBJECT
@@ -54,6 +56,7 @@ private:
         bool hasStroke;
         bool hasFill;
         bool isClosed;
+        Clipper2Lib::Paths64 clipperGeometry;
 
         PathSegment()
             : item(nullptr)


### PR DESCRIPTION
## Summary
- cache clipper-ready geometry on each path segment so bucket fill can reuse polygonal data when composing fills
- rewrite composeRegionFromSegments to work directly from the cached clipper geometry, union expanded strokes to close gaps, and reconstruct the enclosed region without shrinking it back open

## Testing
- not run (Qt build environment not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d18bfcda8c8321985a3a2c88b27322